### PR TITLE
Update hyprland.conf - Toggle rofi instead of purely launching it

### DIFF
--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -205,9 +205,10 @@ bind = $mainMod, T, exec, kitty # open terminal
 bind = $mainMod, E, exec, dolphin # open file manager
 bind = $mainMod, V, exec, code # open vs code
 bind = $mainMod, F, exec, firefox # open browser
-bind = $mainMod, A, exec, rofi -show drun # launch desktop applications
-bind = $mainMod, tab, exec, rofi -show window # switch between desktop applications
-bind = $mainMod, R, exec, rofi -show filebrowser # browse system files
+# rofi is toggled on/off if you repeat the key presses
+bind = $mainMod, A, exec, pkill rofi || rofi -show drun # launch desktop applications
+bind = $mainMod, tab, exec, pkill rofi || rofi -show window # switch between desktop applications
+bind = $mainMod, R, exec, pkill rofi || rofi -show filebrowser # browse system files
 
 bind = , F10, exec, ~/.config/hypr/scripts/volumecontrol.sh m # mute audio output
 bind = , F11, exec, ~/.config/hypr/scripts/volumecontrol.sh d # decrease volume


### PR DESCRIPTION
TL;DR: Repeating a keypress used to launch rofi (e.g. $mainMod, A) will close it back.

Hello, 

I hope it's OK to send you pull requests! In my daily use, I find it convenient to repeat the keybind for rofi to close it back. Perhaps you'll find it convenient too?

In my case, I use the "Windows" key without any extra modifier for rofi -show drun, but I did not touch your actual keybinding and left it to "mainMod + A".


Bests,
Hugo


