### PR TITLE
The glyph was being cut due to a window padding of 0

### DIFF
--- a/Configs/.config/waybar/modules/style.css
+++ b/Configs/.config/waybar/modules/style.css
@@ -120,7 +120,6 @@ tooltip {
 }
 
 #workspaces,
-#window,
 #taskbar {
     padding: 0px;
 }


### PR DESCRIPTION
Hello. I have noticed this behaviour in the waybar.

![swappy-20230703_082925](https://github.com/prasanthrangan/hyprdots/assets/8573/e53c85d9-3a78-4c22-8128-ba29a48cd84e)

The fix addresses the issue and seems to have no side effects. 
Thanks!