### PR TITLE
Waybar battery and system audio icon update

### DIFF
--- a/Configs/.config/waybar/modes/wb_bottom_01.jsonc
+++ b/Configs/.config/waybar/modes/wb_bottom_01.jsonc
@@ -6,7 +6,7 @@
     "exclusive": true,
     "passthrough": false,
     "gtk-layer-shell": true,
-    "modules-left": ["custom/l_end","cpu","memory","custom/r_end","custom/l_end","clock","custom/r_end"],
+    "modules-left": ["custom/l_end","cpu","memory","battery","custom/r_end","custom/l_end","clock","custom/r_end"],
     "modules-center": ["custom/l_end","wlr/workspaces","hyprland/window","custom/r_end"],
     "modules-right": ["custom/l_end","network","bluetooth","pulseaudio","pulseaudio#microphone","custom/updates","custom/r_end",
         "custom/l_end","tray","custom/r_end",

--- a/Configs/.config/waybar/modes/wb_top_01.jsonc
+++ b/Configs/.config/waybar/modes/wb_top_01.jsonc
@@ -8,7 +8,7 @@
     "gtk-layer-shell": true,
     "modules-left": ["custom/l_end","wlr/workspaces","hyprland/window","custom/r_end"],
     "modules-center": ["custom/l_end","clock","custom/r_end"],
-    "modules-right": ["custom/l_end","cpu","memory","custom/r_end",
+    "modules-right": ["custom/l_end","cpu","memory","battery","custom/r_end",
         "custom/l_end","network","bluetooth","pulseaudio","pulseaudio#microphone","custom/updates","custom/r_end",
         "custom/l_end","tray","custom/r_end",
         "custom/l_end","custom/wallchange","custom/mode","custom/wbar", "custom/cliphist","custom/power","custom/r_end"],

--- a/Configs/.config/waybar/modules/battery.jsonc
+++ b/Configs/.config/waybar/modules/battery.jsonc
@@ -1,0 +1,13 @@
+    "battery": {
+        "states": {
+            "good": 95,
+            "warning": 30,
+            "critical": 20
+        },
+        "format": "{icon} {capacity}%",
+        "format-charging": " {capacity}%",
+        "format-plugged": " {capacity}%",
+        "format-alt": "{time} {icon}",
+        "format-icons": ["󰂎", "󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
+    },
+

--- a/Configs/.config/waybar/modules/pulseaudio.jsonc
+++ b/Configs/.config/waybar/modules/pulseaudio.jsonc
@@ -1,5 +1,5 @@
     "pulseaudio": {
-        "format": "{icon}",
+        "format": "{icon} {volume}",
         "format-muted": "婢",
         "on-click": "pavucontrol -t 3",
         "on-click-middle": "~/.config/hypr/scripts/volumecontrol.sh m",

--- a/Configs/.config/waybar/modules/style.css
+++ b/Configs/.config/waybar/modules/style.css
@@ -92,6 +92,7 @@ tooltip {
 
 #cpu,
 #memory,
+#battery,
 #clock,
 #workspaces,
 #window,


### PR DESCRIPTION
I noticed that the battery for Waybar is on your to-do list, so I thought I'd chip in with my edited Waybar config. Additionally, I have optionally added a percentage to the system audio icon to indicate the current volume.