### PR TITLE
Fixing all Hyprland themes after v0.28.0 blur changes

### DIFF
--- a/Configs/.config/hypr/themes/Catppuccin-Latte.conf
+++ b/Configs/.config/hypr/themes/Catppuccin-Latte.conf
@@ -28,14 +28,17 @@ general {
 
 decoration {
     rounding = 10
-    blur = yes
-    blur_size = 6
-    blur_passes = 3
-    blur_new_optimizations = on
-    blur_ignore_opacity = on
     multisample_edges = true
     drop_shadow = false
-    blur_xray = false
+
+    blur {
+        enabled = yes
+        size = 6
+        passes = 3
+        new_optimizations = on
+        ignore_opacity = on
+        xray = false
+    }
 }
 
 blurls = waybar

--- a/Configs/.config/hypr/themes/Catppuccin-Mocha.conf
+++ b/Configs/.config/hypr/themes/Catppuccin-Mocha.conf
@@ -28,14 +28,17 @@ general {
 
 decoration {
     rounding = 10
-    blur = yes
-    blur_size = 6
-    blur_passes = 3
-    blur_new_optimizations = on
-    blur_ignore_opacity = on
     multisample_edges = true
     drop_shadow = false
-    blur_xray = false
+
+    blur {
+        enabled = yes
+        size = 6
+        passes = 3
+        new_optimizations = on
+        ignore_opacity = on
+        xray = false
+    }
 }
 
 blurls = waybar

--- a/Configs/.config/hypr/themes/Decay-Green.conf
+++ b/Configs/.config/hypr/themes/Decay-Green.conf
@@ -28,14 +28,17 @@ general {
 
 decoration {
     rounding = 10
-    blur = yes
-    blur_size = 5
-    blur_passes = 4
-    blur_new_optimizations = on
-    blur_ignore_opacity = on
     multisample_edges = true
     drop_shadow = false
-    blur_xray = true
+
+    blur {
+        enabled = yes
+        size = 5
+        passes = 4
+        new_optimizations = on
+        ignore_opacity = on
+        xray = true
+    }
 }
 
 #blurls = waybar

--- a/Configs/.config/hypr/themes/Material-Sakura.conf
+++ b/Configs/.config/hypr/themes/Material-Sakura.conf
@@ -28,19 +28,22 @@ general {
 
 decoration {
     rounding = 12
-    blur = yes
-    blur_size = 6
-    blur_passes = 3
-    blur_new_optimizations = on
-    blur_ignore_opacity = on
     multisample_edges = true
-    blur_xray = false
     drop_shadow = true
     shadow_ignore_window = true
     shadow_offset = 9 10
     shadow_range = 5
     shadow_render_power = 4
     col.shadow = 0xff26233a
+
+    blur {
+        enabled = yes
+        size = 6
+        passes = 3
+        new_optimizations = on
+        ignore_opacity = on
+        xray = false
+    }
 }
 
 #blurls = waybar

--- a/Configs/.config/hypr/themes/Rose-Pine.conf
+++ b/Configs/.config/hypr/themes/Rose-Pine.conf
@@ -27,14 +27,17 @@ general {
 
 decoration {
     rounding = 10
-    blur = yes
-    blur_size = 6
-    blur_passes = 3
-    blur_new_optimizations = on
-    blur_ignore_opacity = on
     multisample_edges = true
     drop_shadow = false
-    blur_xray = false
+
+    blur {
+        enabled = yes
+        size = 6
+        passes = 3
+        new_optimizations = on
+        ignore_opacity = on
+        xray = false
+    }
 }
 
 blurls = waybar

--- a/Configs/.config/hypr/themes/Tokyo-Night.conf
+++ b/Configs/.config/hypr/themes/Tokyo-Night.conf
@@ -27,14 +27,17 @@ general {
 
 decoration {
     rounding = 10
-    blur = yes
-    blur_size = 6
-    blur_passes = 3
-    blur_new_optimizations = on
-    blur_ignore_opacity = on
     multisample_edges = true
     drop_shadow = false
-    blur_xray = true
+
+    blur {
+        enabled = yes
+        size = 6
+        passes = 3
+        new_optimizations = on
+        ignore_opacity = on
+        xray = true
+    }
 }
 
 blurls = waybar


### PR DESCRIPTION
Hello,

In the last Hyprland update `blur` variables have been moved under a new subcategory `decoration:blur`, see [Release v0.28.0 - hyprwm/Hyprland](https://github.com/hyprwm/Hyprland/releases/tag/v0.28.0).

I have therefore applied these changes to all config files under [Configs/.config/hypr/themes/](https://github.com/prasanthrangan/hyprdots/tree/main/Configs/.config/hypr/themes).

P.S.: I love these dots, thank you <3
