### PR TITLE
Use a unified path to save screenshots (for grim/swappy)

### DIFF
--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -55,7 +55,7 @@ env = QT_QPA_PLATFORM,wayland
 env = QT_QPA_PLATFORMTHEME,qt5ct
 env = QT_WAYLAND_DISABLE_WINDOWDECORATION,1
 env = QT_AUTO_SCREEN_SCALE_FACTOR,1
-
+env = XDG_PICTURES_DIR,$HOME/Pictures
 
 
 # █ █▄░█ █▀█ █░█ ▀█▀

--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -47,7 +47,7 @@ binde = , XF86MonBrightnessDown, exec, ~/.config/hypr/scripts/brightnesscontrol.
 
 # screenshot/screencapture
 bind = $mainMod, P, exec, grim -g "$(slurp)" - | swappy -f - # screenshot snip
-bind = $mainMod_ALT, P, exec, grim ~/Apps/grim/$(date +'%y%m%d_%Hh%Mm%Ss_screenshot.png') # print current screen
+bind = $mainMod_ALT, P, exec, grim $XDG_PICTURES_DIR/$(date +'%y%m%d_%Hh%Mm%Ss_screenshot.png') # print current screen
 bind = $CONTROL_SHIFT, P, pass, ^(com\.obsproject\.Studio)$ # start/stop obs screen recording
 
 # exec custom scripts

--- a/Configs/.config/swappy/config
+++ b/Configs/.config/swappy/config
@@ -1,0 +1,3 @@
+[Default]
+save_dir=$XDG_PICTURES_DIR
+save_filename_format=%y%m%d_%Hh%Mm%Ss_screenshot.png

--- a/Scripts/restore_cfg.lst
+++ b/Scripts/restore_cfg.lst
@@ -8,6 +8,7 @@ ${HOME}/.config|MangoHud|mangohud
 ${HOME}/.config|neofetch|neofetch
 ${HOME}/.config|qt5ct|qt5ct
 ${HOME}/.config|rofi|rofi
+${HOME}/.config|swappy|swappy
 ${HOME}/.config|swaylock|swaylock-effects
 ${HOME}/.config|swww|swww
 ${HOME}/.config|waybar|waybar


### PR DESCRIPTION
Hello Prasan,


Screenshots (full screen) are currently saved under ~/Apps/grim, as per this keybinding:
`bind = $mainMod ALT, P, exec, grim ~/Apps/grim/$(date +'%y%m%d_%Hh%Mm%Ss_screenshot.png') # print current screen`
~/Apps is not a default path for Arch, and most distros I know of.

Meanwhile, cropped screenshots are saved under whatever is the default for Swappy on your distro (on Arch, for example: https://man.archlinux.org/man/swappy.1.en)

This is inconsistent, makes me a sad potato, and wakes me up at night. What about placing screenshots by default under ~/Pictures, which is much more common? Users could define their own path by overwriting a variable in userprefs.conf
Install scripts could also make sure ~/Pictures exist, and if not create it (which again, strikes me as reasonable). Alternatively, the README could state that this path should exist, or the variable should be edited by the user.

So, what this commit does:
1°/ Create a new variable in hyprland.conf: XDG_PICTURES_DIR, which will be used as the path for screenshots.
_I picked this variable as it seems semi-commonly used, as per https://wiki.archlinux.org/title/XDG_user_directories_
2°/ Create a config file for swappy (path: ~/.config/swappy/config), so it saves to this new directory by default, using the file name format you picked for grim:
```
[Default]
save_dir=$XDG_PICTURES_DIR
save_filename_format=%y%m%d_%Hh%Mm%Ss_screenshot.png
```
3°/ For grim full screenshots, update the keybind to:
`bind = $mainMod ALT, P, exec, grim $XDG_PICTURES_DIR/$(date +'%y%m%d_%Hh%Mm%Ss_screenshot.png') # print current screen`
4°/ Update the install script to make sure  ~/.config/swappy is sync'd. 
5°/ Makes me a happy potato :-)

What this commit does not do:
Update the install script to create the $HOME/Pictures folder, or update the README to ask users to do this manually.


Cheers,
Hugo