### PR TITLE
Auto-generate wallpaper thumbnails

### DIFF
--- a/Scripts/create_cache.sh
+++ b/Scripts/create_cache.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+
+# set variables
+ctlFile="$HOME/.config/swww/wall.ctl"
+ThemeList="$(awk -F '|' '{print $2}' $ctlFile)"
+SwwwPath="$HOME/.config/swww"
+CacheDir="$HOME/.config/swww/.cache"
+ForceOverwrite=false
+
+# evaluate options
+while getopts "f" option ; do
+    case $option in
+    f ) # set next wallpaper
+        ForceOverwrite=true ;;
+    * ) # invalid option
+    	echo "f : force creation of thumbnails (ignore existing)"
+        exit 1 ;;
+    esac
+done
+
+# create thumbnails for each theme > wallpapers
+for theme in ${ThemeList}
+do
+    if [ ! -d ${CacheDir}/${theme} ] ; then
+        mkdir -p ${CacheDir}/${theme}
+    fi
+
+    # Map all wallpapers from the theme to an array with -print0, in case someone decided to use spaces
+    mapfile -d '' wpArray < <(find ${SwwwPath}/${theme} -type f -print0)
+
+    echo "Creating up to ${#wpArray[@]} thumbnails for ${theme}"
+   
+    for wpFullName in "${wpArray[@]}"
+    do
+	wpBaseName=$(basename "${wpFullName}")
+	if [ ! -f "${CacheDir}/${theme}/${wpBaseName}" ] || [ $ForceOverwrite == true ] ; then
+	   convert "${wpFullName}" -thumbnail 500x500^ -gravity center -extent 500x500 "${CacheDir}/${theme}/${wpBaseName}"
+        fi
+    done
+
+done

--- a/Scripts/create_cache.sh
+++ b/Scripts/create_cache.sh
@@ -13,7 +13,7 @@ while getopts "f" option ; do
     f ) # set next wallpaper
         ForceOverwrite=true ;;
     * ) # invalid option
-    	echo "f : force creation of thumbnails (ignore existing)"
+    	echo "f : force creation of new thumbnails (delete old cache)"
         exit 1 ;;
     esac
 done
@@ -21,6 +21,10 @@ done
 # create thumbnails for each theme > wallpapers
 for theme in ${ThemeList}
 do
+    if [ $ForceOverwrite == true ]; then
+       rm -Rf ${CacheDir}/${theme}
+    fi
+
     if [ ! -d ${CacheDir}/${theme} ] ; then
         mkdir -p ${CacheDir}/${theme}
     fi
@@ -33,7 +37,7 @@ do
     for wpFullName in "${wpArray[@]}"
     do
 	wpBaseName=$(basename "${wpFullName}")
-	if [ ! -f "${CacheDir}/${theme}/${wpBaseName}" ] || [ $ForceOverwrite == true ] ; then
+	if [ ! -f "${CacheDir}/${theme}/${wpBaseName}" ] ; then
 	   convert "${wpFullName}" -thumbnail 500x500^ -gravity center -extent 500x500 "${CacheDir}/${theme}/${wpBaseName}"
         fi
     done


### PR DESCRIPTION
Hey Prasan,


I noticed that  you are storing thumbnails for swww (under .cache) directly on Git. The goal of this commit is to reduce the size of the repository by removing cached files that can be generated locally by the user.

To avoid generating thumbnails "on the fly", I have created a script to generate the cache during the installation process. 
Adding this step during the installation process would avoid having users face a slow-down the first time they would open, for example, the theme or wallpaper selector.

There's a -f (for force) flag that you can pass to delete the existing .cache/theme_abc folders and recreate them from scratch. Might be useful if you delete / change wallpapers down the line.

I am not sure where you'd like to include this script in the installation process (if you indeed want to include it).
It needs to be somewhere after the config files for swww have been copied, it relies on $HOME/.config/swww/wall.ctl to get the list of themes. I'd suggest including it in install.sh:
- When the user passes the *restore* flag alone, run the script with no parameters (will only generate missing thumbnails, won't destroy anything)
- When the user passes no flag (install everything), run the script with -f (nukes any existing cached "Theme" thumbnails under swww)

_(I noticed there is already a part of the function Wall_Update in the script  $HOME/.config/hypr/scripts/swwwallpaper.sh that can automatically generate the thumbnail on updates, but it's for the current theme, generates a single thumbnail, and as I said, generating all thumbnails at once when the user open e.g. the wallpaper selector for the first time would be a bit slow and annoying.)_

On a side note, I love the wallpapers and themes selectors, thanks for the update on these! :-)


Cheers,
Hugo