### PR TITLE
Use the shortcut keys to open the pasteboard

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -59,7 +59,7 @@ bind = $mainMod ALT, down, exec, ~/.config/waybar/wbarconfgen.sh p # previous wa
 bind = $mainMod SHIFT, T, exec, pkill rofi || ~/.config/hypr/scripts/themeselect.sh # theme select menu
 bind = $mainMod SHIFT, A, exec, pkill rofi || ~/.config/hypr/scripts/rofiselect.sh # rofi style select menu
 bind = $mainMod SHIFT, W, exec, pkill rofi || ~/.config/hypr/scripts/swwwallselect.sh # rofi wall select menu
-
+bind = $mainMod ALT, V, exec, ~/.config/hypr/scripts/cliphist.sh c 5  # open Pasteboard in screen center
 # Move focus with mainMod + arrow keys
 bind = $mainMod, left, movefocus, l
 bind = $mainMod, right, movefocus, r

--- a/Configs/.config/hypr/scripts/cliphist.sh
+++ b/Configs/.config/hypr/scripts/cliphist.sh
@@ -19,6 +19,9 @@ case $2 in
     4)  # bottom right
         pos="window {location: south west; anchor: south west; x-offset: 20px; y-offset: -20px;}"
         ;;
+    5)  # center in screen
+        pos="window {location: center; anchor: center;}"
+        ;;
 esac
 
 


### PR DESCRIPTION
Use Win+ALT+V to quickly open the pasteboard