### PR TITLE
Change temp icon in gpuinfo

### DIFF
--- a/Configs/.config/waybar/modules/gpuinfo.jsonc
+++ b/Configs/.config/waybar/modules/gpuinfo.jsonc
@@ -1,7 +1,7 @@
 "custom/gpuinfo": {
-    "exec": " ~/.config/hypr/scripts/gpuinfo.sh",
-    "return-type": "json",
-    "format": "󰈸 {}",
-    "interval" : 2, // once every 2 seconds
-    "tooltip": true,
+  "exec": " ~/.config/hypr/scripts/gpuinfo.sh",
+  "return-type": "json",
+  "format": "🌡 {}",
+  "interval": 2, // once every 2 seconds
+  "tooltip": true,
 },


### PR DESCRIPTION
I think the following
![image](https://github.com/prasanthrangan/hyprdots/assets/82440615/909fa3ab-20d2-4c97-b074-374f741151aa)
it's more clear than the fire icon.