### PR TITLE
Update gamelauncher.sh

### DIFF
--- a/Configs/.config/hypr/scripts/gamelauncher.sh
+++ b/Configs/.config/hypr/scripts/gamelauncher.sh
@@ -59,7 +59,7 @@ done | rofi -dmenu -theme-str "${r_override}" -config $RofiConf)
 # launch game
 if [ ! -z "$RofiSel" ] ; then
     launchid=`echo "$GameList" | grep "$RofiSel" | cut -d '|' -f 2`
-    steam -applaunch ${launchid} [gamemoderun %command%] &
+    steam -applaunch "${launchid} [gamemoderun %command%]" &
     dunstify $ncolor "theme" -a "Launching ${RofiSel}..." -i ${SteamThumb}/${launchid}_header.jpg -r 91190 -t 2200
 fi
 


### PR DESCRIPTION
Add in quotation marks for correct path formatting. Tested with skyrim SE with a custom launch parameter and black ops 3 without a launch parameter. 