### PR TITLE
Trigger swaylock when close laptop lid, adjust OBS shortcut and add alt+f4 shortcut...

### DIFF
--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -40,7 +40,7 @@ exec-once = wl-paste --type image --watch cliphist store # clipboard store image
 exec-once = ~/.config/hypr/scripts/swwwallpaper.sh # start wallpaper daemon
 exec-once = ~/.config/hypr/scripts/batterynotify.sh # battery notification
 # turn off the monitor after 20 mins and suspend after 30 mins of inactivity
-exec-once = swayidle -w timeout 1200 'swaylock; hyprctl dispatch dpms off' resume 'hyprctl dispatch dpms on' timeout 1800 'systemctl suspend'
+# exec-once = swayidle -w timeout 1200 'swaylock; hyprctl dispatch dpms off' resume 'hyprctl dispatch dpms on' timeout 1800 'systemctl suspend'
 
 
 # █▀▀ █▄░█ █░█

--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -39,7 +39,8 @@ exec-once = wl-paste --type text --watch cliphist store # clipboard store text d
 exec-once = wl-paste --type image --watch cliphist store # clipboard store image data
 exec-once = ~/.config/hypr/scripts/swwwallpaper.sh # start wallpaper daemon
 exec-once = ~/.config/hypr/scripts/batterynotify.sh # battery notification
-# exec-once = swayidle -w timeout 900 'swaylock; hyprctl dispatch dpms off' resume 'hyprctl dispatch dpms on' # turn off monitor after 15 mins
+# turn off the monitor after 20 mins and suspend after 30 mins of inactivity
+exec-once = swayidle -w timeout 1200 'swaylock; hyprctl dispatch dpms off' resume 'hyprctl dispatch dpms on' timeout 1800 'systemctl suspend'
 
 
 # █▀▀ █▄░█ █░█

--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -129,9 +129,5 @@ bind = $mainMod ALT, 8, movetoworkspacesilent, 8
 bind = $mainMod ALT, 9, movetoworkspacesilent, 9
 bind = $mainMod ALT, 0, movetoworkspacesilent, 10
 
-# Trigger when the switch is toggled
-bindl= , switch:Lid Switch, exec, swaylock
-# Trigger when the switch is turning on
-bindl= , switch:on:Lid Switch, exec, hyprctl dispatch dpms on
 # Trigger when the switch is turning off
-bindl= , switch:off:Lid Switch, exec, hyprctl dispatch dpms off
+bindl= , switch:on:Lid Switch, exec, swaylock && systemctl suspend

--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -11,6 +11,7 @@ $mainMod = SUPER # windows key
 
 # window/session actions
 bind = $mainMod, Q, exec, ~/.config/hypr/scripts/dontkillsteam.sh # killactive, # kill the window on focus
+bind = ALT, F4, exec, ~/.config/hypr/scripts/dontkillsteam.sh # killactive, # kill the window on focus
 bind = $mainMod, delete, exit, # kill hyperland session
 bind = $mainMod, W, togglefloating, # toggle the window on focus to float
 bind = $mainMod, G, togglegroup, # toggle the window on focus to float

--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -106,7 +106,7 @@ bind = $mainMod SHIFT, 0, movetoworkspace, 10
 bind = $mainMod, mouse_down, workspace, e+1
 bind = $mainMod, mouse_up, workspace, e-1
 
-# Move/resize windows with mainMod + LMB/RMB and dragging
+# Move/Resize windows with mainMod + LMB/RMB and dragging
 bindm = $mainMod, mouse:272, movewindow
 bindm = $mainMod, mouse:273, resizewindow
 

--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -6,10 +6,10 @@
 # See https://wiki.hyprland.org/Configuring/Keywords/ for more
 # Example binds, see https://wiki.hyprland.org/Configuring/Binds/ for more
 
-# main modifier
+# Main modifier
 $mainMod = SUPER # windows key
 
-# window/session actions
+# Window/Session actions
 bind = $mainMod, Q, exec, ~/.config/hypr/scripts/dontkillsteam.sh # killactive, # kill the window on focus
 bind = ALT, F4, exec, ~/.config/hypr/scripts/dontkillsteam.sh # killactive, # kill the window on focus
 bind = $mainMod, delete, exit, # kill hyperland session
@@ -19,23 +19,23 @@ bind = ALT, return, fullscreen, # toggle the window on focus to fullscreen
 bind = $mainMod, L, exec, swaylock # lock screen
 bind = $mainMod, backspace, exec, ~/.config/hypr/scripts/logoutlaunch.sh 1 # logout menu
 
-# application shortcuts
+# Application shortcuts
 bind = $mainMod, T, exec, kitty # open terminal
 bind = $mainMod, E, exec, dolphin # open file manager
 bind = $mainMod, C, exec, code # open vs code
 bind = $mainMod, F, exec, firefox # open browser
 
-# rofi is toggled on/off if you repeat the key presses
+# Rofi is toggled on/off if you repeat the key presses
 bind = $mainMod, A, exec, pkill rofi || ~/.config/hypr/scripts/rofilaunch.sh d # launch desktop applications
 bind = $mainMod, tab, exec, pkill rofi || ~/.config/hypr/scripts/rofilaunch.sh w # switch between desktop applications
 bind = $mainMod, R, exec, pkill rofi || ~/.config/hypr/scripts/rofilaunch.sh f # browse system files
 
-# audio control
+# Audio control
 bind  = , F10, exec, ~/.config/hypr/scripts/volumecontrol.sh -o m # toggle audio mute
 binde = , F11, exec, ~/.config/hypr/scripts/volumecontrol.sh -o d # decrease volume
 binde = , F12, exec, ~/.config/hypr/scripts/volumecontrol.sh -o i # increase volume
-binde = $mainMod ctrl, down, exec, ~/.config/hypr/scripts/spotifyvolumecontrol.sh down # decrease volume for spotify
-binde = $mainMod ctrl, up, exec, ~/.config/hypr/scripts/spotifyvolumecontrol.sh up # increase volume for spotify
+binde = $mainMod $CONTROL, down, exec, ~/.config/hypr/scripts/spotifyvolumecontrol.sh down # decrease volume for spotify
+binde = $mainMod $CONTROL, up, exec, ~/.config/hypr/scripts/spotifyvolumecontrol.sh up # increase volume for spotify
 bind  = , XF86AudioMute, exec, ~/.config/hypr/scripts/volumecontrol.sh -o m # toggle audio mute
 bind  = , XF86AudioMicMute, exec, ~/.config/hypr/scripts/volumecontrol.sh -i m # toggle microphone mute
 binde = , XF86AudioLowerVolume, exec, ~/.config/hypr/scripts/volumecontrol.sh -o d # decrease volume
@@ -45,16 +45,16 @@ bind  = , XF86AudioPause, exec, playerctl play-pause
 bind  = , XF86AudioNext, exec, playerctl next
 bind  = , XF86AudioPrev, exec, playerctl previous
 
-# brightness control
+# Brightness control
 binde = , XF86MonBrightnessUp, exec, ~/.config/hypr/scripts/brightnesscontrol.sh i # increase brightness
 binde = , XF86MonBrightnessDown, exec, ~/.config/hypr/scripts/brightnesscontrol.sh d # decrease brightness
 
-# screenshot/screencapture
+# Screenshot/Screencapture
 bind = $mainMod, P, exec, ~/.config/hypr/scripts/screenshot.sh s # screenshot snip
 bind = $mainMod ALT, P, exec, ~/.config/hypr/scripts/screenshot.sh p # print current screen
 bind = $CONTROL ALT SHIFT, R, exec, obs # open obs
 
-# exec custom scripts
+# Exec custom scripts
 bind = $mainMod ALT, G, exec, ~/.config/hypr/scripts/gamemode.sh # disable hypr effects for gamemode
 bind = $mainMod ALT, right, exec, ~/.config/hypr/scripts/swwwallpaper.sh -n # next wallpaper
 bind = $mainMod ALT, left, exec, ~/.config/hypr/scripts/swwwallpaper.sh -p # previous wallpaper
@@ -110,7 +110,7 @@ bind = $mainMod, mouse_up, workspace, e-1
 bindm = $mainMod, mouse:272, movewindow
 bindm = $mainMod, mouse:273, resizewindow
 
-# Special workspaces (scratchpad) 
+# Special workspaces (scratchpad)
 bind = $mainMod ALT, S, movetoworkspacesilent, special
 bind = $mainMod, S, togglespecialworkspace,
 
@@ -129,9 +129,9 @@ bind = $mainMod ALT, 8, movetoworkspacesilent, 8
 bind = $mainMod ALT, 9, movetoworkspacesilent, 9
 bind = $mainMod ALT, 0, movetoworkspacesilent, 10
 
-# trigger when the switch is toggled
-bindl=,switch:Lid Switch,exec,swaylock
-# trigger when the switch is turning on
-bindl=,switch:on:Lid Switch,exec,hyprctl dispatch dpms on
-# trigger when the switch is turning off
-bindl=,switch:off:Lid Switch,exec,hyprctl dispatch dpms off
+# Trigger when the switch is toggled
+bindl= , switch:Lid Switch, exec, swaylock
+# Trigger when the switch is turning on
+bindl= , switch:on:Lid Switch, exec, hyprctl dispatch dpms on
+# Trigger when the switch is turning off
+bindl= , switch:off:Lid Switch, exec, hyprctl dispatch dpms off

--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -51,7 +51,7 @@ binde = , XF86MonBrightnessDown, exec, ~/.config/hypr/scripts/brightnesscontrol.
 # screenshot/screencapture
 bind = $mainMod, P, exec, ~/.config/hypr/scripts/screenshot.sh s # screenshot snip
 bind = $mainMod ALT, P, exec, ~/.config/hypr/scripts/screenshot.sh p # print current screen
-# bind = $CONTROL SHIFT, P, pass, ^(com\.obsproject\.Studio)$ # start/stop obs screen recording
+bind = $CONTROL ALT SHIFT, R, exec, obs # open obs
 
 # exec custom scripts
 bind = $mainMod ALT, G, exec, ~/.config/hypr/scripts/gamemode.sh # disable hypr effects for gamemode

--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -128,3 +128,9 @@ bind = $mainMod ALT, 8, movetoworkspacesilent, 8
 bind = $mainMod ALT, 9, movetoworkspacesilent, 9
 bind = $mainMod ALT, 0, movetoworkspacesilent, 10
 
+# trigger when the switch is toggled
+bindl=,switch:Lid Switch,exec,swaylock
+# trigger when the switch is turning on
+bindl=,switch:on:Lid Switch,exec,hyprctl dispatch dpms on
+# trigger when the switch is turning off
+bindl=,switch:off:Lid Switch,exec,hyprctl dispatch dpms off

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ pokemon-colorscripts-git | display pokemon sprites
 | Keys | Action |
 | :--  | :-- |
 | <kbd>Super</kbd> + <kbd>Q</kbd> | quit active/focused window
+| <kbd>Alt</kbd> + <kbd>F4</kbd> | quit active/focused window
 | <kbd>Super</kbd> + <kbd>Del</kbd> | quit hyprland session
 | <kbd>Super</kbd> + <kbd>W</kbd> | toggle window on focus to float
 | <kbd>Alt</kbd> + <kbd>Enter</kbd> | toggle window on focus to fullscreen
@@ -247,7 +248,7 @@ pokemon-colorscripts-git | display pokemon sprites
 | <kbd>Super</kbd> + <kbd>G</kbd> | toggle window group
 | <kbd>Super</kbd> + <kbd>T</kbd> | launch kitty terminal
 | <kbd>Super</kbd> + <kbd>E</kbd> | launch dolphin file explorer
-| <kbd>Super</kbd> + <kbd>C</kbd> | launch vs code
+| <kbd>Super</kbd> + <kbd>C</kbd> | launch vscode
 | <kbd>Super</kbd> + <kbd>F</kbd> | launch firefox
 | <kbd>Super</kbd> + <kbd>A</kbd> | launch desktop applications (rofi)
 | <kbd>Super</kbd> + <kbd>Tab</kbd> | switch open applications (rofi)
@@ -260,6 +261,7 @@ pokemon-colorscripts-git | display pokemon sprites
 | <kbd>Super</kbd> + <kbd>Backspace</kbd> | logout menu
 | <kbd>Super</kbd> + <kbd>P</kbd> | screenshot snip
 | <kbd>Super</kbd> + <kbd>Alt</kbd> + <kbd>P</kbd> | print current screen
+| <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd> | launch obs
 | <kbd>Super</kbd> + <kbd>RightClick</kbd> | resize the window 
 | <kbd>Super</kbd> + <kbd>LeftClick</kbd> | change the window position
 | <kbd>Super</kbd> + <kbd>MouseScroll</kbd> | cycle through workspaces


### PR DESCRIPTION
Hi there! I just implemented a new feature that trigger swaylock in whenever we close the laptop lid
I noticed that swaylock wasn't activating when the laptop lid was closed, which could be a potential security risk. So, I added this feature to enhance the security aspect
I've personally tested this on my laptop, and it's working as intended. However, you should double check to ensure everything's functioning seamlessly ✅ 
This feature won't affect desktop computers since they don't have a lid to close, you know =)))

In addition, I've made a small adjustment to the OBS opening shortcut. Instead of using Ctrl + Shift + P, which could clash with the Firefox private browsing tab shortcut, I've opted for Ctrl + Alt + Shift + R. This shortcut is commonly used in Linux for recording screen

Lastly, I've added the keyboard shortcut Alt + F4 for closing the window. When I first started using your dotfile, finding the window close shortcut was a bit challenging. This new shortcut will definitely make it more accessible, especially for newcomers to the dotfile

Also, I made some changes to the comment to capitalize the first letter and adjust some stuff to make it look better