### PR TITLE
Rerun the folder creation as root if it fails with current user

### DIFF
--- a/Scripts/restore_fnt.sh
+++ b/Scripts/restore_fnt.sh
@@ -4,6 +4,7 @@
 #|-/ /--| Prasanth Rangan                  |-/ /--|#
 #|/ /---+----------------------------------+/ /---|#
 
+set +x
 source global_fn.sh
 if [ $? -ne 0 ] ; then
     echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
@@ -19,8 +20,8 @@ do
 
     if [ ! -d "${tgt}" ]
     then
-        mkdir -p ${tgt}
-        echo "${tgt} directory created..."
+      mkdir ${tgt} || echo "creating the directory as root instead..." && sudo mkdir -p ${tgt}
+      echo "${tgt} directory created..."
     fi
 
     sudo tar -xzf ${CloneDir}/Source/arcs/${fnt}.tar.gz -C ${tgt}/


### PR DESCRIPTION
Hello hello,


Very simple change, this was always failing on my side because I do not have grub installed, and so the folder /usr/share/grub didn't exist, and couldn't be created by my local user without sudo.


Bests,
Hugo