### PR TITLE
Fix system update execution to work with any AUR wrapper

### DIFF
--- a/Configs/.config/hypr/scripts/systemupdate.sh
+++ b/Configs/.config/hypr/scripts/systemupdate.sh
@@ -36,6 +36,6 @@ fi
 
 # Trigger upgrade
 if [ "$1" == "up" ] ; then
-    kitty --title systemupdate sh -c "yay -Syu $fpk_exup"
+    kitty --title systemupdate sh -c "${aurhlpr} -Syu $fpk_exup"
 fi
 


### PR DESCRIPTION
I discovered that clicking the system update never worked and I discovered it is because the script doesn't launch the update process with the installed AUR wrapper and instead hardcodes yay. This will fix it. 