### PR TITLE
feat: add keybinds to move active window around with arrow keys

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -111,6 +111,12 @@ bind = $mainMod SHIFT, 8, movetoworkspace, 8
 bind = $mainMod SHIFT, 9, movetoworkspace, 9
 bind = $mainMod SHIFT, 0, movetoworkspace, 10
 
+# Move active window around current workspace with mainMod + SHIFT + CTRL [←→↑↓]
+bind = $mainMod SHIFT $CONTROL, left, movewindow, l
+bind = $mainMod SHIFT $CONTROL, right, movewindow, r
+bind = $mainMod SHIFT $CONTROL, up, movewindow, u
+bind = $mainMod SHIFT $CONTROL, down, movewindow, d
+
 # Scroll through existing workspaces with mainMod + scroll
 bind = $mainMod, mouse_down, workspace, e+1
 bind = $mainMod, mouse_up, workspace, e-1
@@ -126,7 +132,7 @@ bind = $mainMod, S, togglespecialworkspace,
 # Toggle Layout
 bind = $mainMod, J, togglesplit, # dwindle
 
-# Move window to workspace Super + Alt + [0-9]
+# Move window silently to workspace Super + Alt + [0-9]
 bind = $mainMod ALT, 1, movetoworkspacesilent, 1
 bind = $mainMod ALT, 2, movetoworkspacesilent, 2
 bind = $mainMod ALT, 3, movetoworkspacesilent, 3


### PR DESCRIPTION
## Move active window around with arrow keys (keycombo + ←→↑↓)

### A simple yet nice to have feature, quality of life as you will

**Usage:**
`$mainMod SHIFT, $CONTROL, ArrowKeys [←→↑↓]`

**alternative option:**
The caviate is that we have to modify the **Spotify vol ctrl**.
_I suggest:_
`$mainMod $CONTROL, ALT, Up/Down [↑↓]`

So we could move active windows around with:
`$mainMod $CONTROL, ArrowKeys [←→↑↓]`
