### PR TITLE
Dunst won't start itself after Theme/wallpaper etc change

### DIFF
--- a/Configs/.config/hypr/wallbash/dunst.dcol
+++ b/Configs/.config/hypr/wallbash/dunst.dcol
@@ -1,4 +1,4 @@
-4|cat $HOME/.config/dunst/dunst.conf $HOME/.config/dunst/Wall-Dcol.conf > $HOME/.config/dunst/dunstrc && killall dunst|.config/dunst/Wall-Dcol.conf
+4|cat $HOME/.config/dunst/dunst.conf $HOME/.config/dunst/Wall-Dcol.conf > $HOME/.config/dunst/dunstrc && killall dunst && dunst &|.config/dunst/Wall-Dcol.conf
 
 [urgency_low]
     background = "<dcol_1>"

--- a/Configs/.config/hypr/wallbash/dunst.dcol
+++ b/Configs/.config/hypr/wallbash/dunst.dcol
@@ -1,4 +1,4 @@
-4|cat $HOME/.config/dunst/dunst.conf $HOME/.config/dunst/Wall-Dcol.conf > $HOME/.config/dunst/dunstrc && killall dunst && dunst &|.config/dunst/Wall-Dcol.conf
+4|cat $HOME/.config/dunst/dunst.conf $HOME/.config/dunst/Wall-Dcol.conf > $HOME/.config/dunst/dunstrc && killall dunst && dunst & disown|.config/dunst/Wall-Dcol.conf
 
 [urgency_low]
     background = "<dcol_1>"


### PR DESCRIPTION
My main system automatically starts Dunst again after killall Dunst with
 ``` 4|cat $HOME/.config/dunst/dunst.conf $HOME/.config/dunst/Wall-Dcol.conf > $HOME/.config/dunst/dunstrc && killall dunst|.config/dunst/Wall-Dcol.conf     ``` 
But my **other** laptop won't restart Dunst after killall dunst leaving my laptop to have no Dunst running unless I run ``` dunst ``` manually. 

I do not know what should be the expected behavior. But appending   ``` && dunst & disown ```  to
``` 4|cat $HOME/.config/dunst/dunst.conf $HOME/.config/dunst/Wall-Dcol.conf > $HOME/.config/dunst/dunstrc && killall dunst && dunst &|.config/dunst/Wall-Dcol.conf  ``` fixes it . 
It won't cause a regression to my Main system BTW. 

This may be due to the my **other** laptop so we can close this if this is not relevant to others. Cheers!