### PR TITLE
Update batterynotify.sh

### DIFF
--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -16,20 +16,20 @@ is_laptop() {
 }
 
 if is_laptop; then
+    while true; do
+        for battery in /sys/class/power_supply/BAT*; do
+            battery_status=$(cat "$battery/status")
+            battery_percentage=$(cat "$battery/capacity")
 
-while true; do
-    battery_status=$(cat /sys/class/power_supply/BAT0/status)
-    battery_percentage=$(cat /sys/class/power_supply/BAT0/capacity)
+            if [ "$battery_status" == "Discharging" ] && [ "$battery_percentage" -le 40 ]; then
+                dunstify -u CRITICAL "Battery Low" "Battery is at $battery_percentage%. Connect the charger."
+            fi
 
-    if [ "$battery_status" == "Discharging" ] && [ "$battery_percentage" -le 20 ]; then
-        dunstify -u CRITICAL "Battery Low" "Battery is at $battery_percentage%. Connect the charger."
-    fi
-
-    if [ "$battery_status" == "Charging" ] && [ "$battery_percentage" -ge 80 ]; then
-        dunstify -u NORMAL "Battery Charged" "Battery is at $battery_percentage%. You can unplug the charger."
-    fi
-
-    sleep 300  # Sleep for 5 minutes before checking again
-  done
-
+            if [ "$battery_status" == "Charging" ] && [ "$battery_percentage" -ge 80 ]; then
+                dunstify -u NORMAL "Battery Charged" "Battery is at $battery_percentage%. You can unplug the charger."
+            fi
+        done
+        sleep 300  # Sleep for 5 minutes before checking again
+    done
 fi
+

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -21,7 +21,7 @@ if is_laptop; then
             battery_status=$(cat "$battery/status")
             battery_percentage=$(cat "$battery/capacity")
 
-            if [ "$battery_status" == "Discharging" ] && [ "$battery_percentage" -le 40 ]; then
+            if [ "$battery_status" == "Discharging" ] && [ "$battery_percentage" -le 20 ]; then
                 dunstify -u CRITICAL "Battery Low" "Battery is at $battery_percentage%. Connect the charger."
             fi
 


### PR DESCRIPTION
Assumes only using one BAT. And assumes to  ```   ls /sys/class/power_supply/      ``` provides BAT*
fix #341 