### PR TITLE
Demonize swaylock before suspending the system, Use swayidle with swaylock for idle timout powermgmt

### DIFF
--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -39,7 +39,7 @@ exec-once = wl-paste --type text --watch cliphist store # clipboard store text d
 exec-once = wl-paste --type image --watch cliphist store # clipboard store image data
 exec-once = ~/.config/hypr/scripts/swwwallpaper.sh # start wallpaper daemon
 exec-once = ~/.config/hypr/scripts/batterynotify.sh # battery notification
-
+exec-once = swayidle -w timeout 300 'swaylock -f' timeout 600 'hyprctl dispatch dpms off' resume 'hyprctl dispatch dpms on' before-sleep 'swaylock -f'
 
 
 # █▀▀ █▄░█ █░█

--- a/Configs/.config/wlogout/layout_1
+++ b/Configs/.config/wlogout/layout_1
@@ -14,7 +14,7 @@
 
 {
     "label" : "suspend",
-    "action" : "swaylock && systemctl suspend",
+    "action" : "swaylock -f && systemctl suspend",
     "text" : "Suspend",
     "keybind" : "u"
 }

--- a/Scripts/custom_hypr.lst
+++ b/Scripts/custom_hypr.lst
@@ -22,6 +22,7 @@ rofi-lbonn-wayland-git
 waybar
 swww
 swaylock-effects-git
+swayidle
 wlogout
 grimblast-git
 slurp


### PR DESCRIPTION
as title suggests, otherwise user needs to unlock swaylock first then the system is suspended. Tested but test yourself too.