### PR TITLE
Daemonize swaylock before suspending the system [Try 2]

### DIFF
--- a/Configs/.config/wlogout/layout_1
+++ b/Configs/.config/wlogout/layout_1
@@ -14,7 +14,7 @@
 
 {
     "label" : "suspend",
-    "action" : "swaylock && systemctl suspend",
+    "action" : "swaylock -f && systemctl suspend",
     "text" : "Suspend",
     "keybind" : "u"
 }


### PR DESCRIPTION
Hi there folks, I messed up in my previous PR but yeah it happens, was my first PR anyway. So, I just came across this problem of swaylock getting in the way of system suspension and the culprit was this line in .config/wlogout/layout_1, it was not daemonized `swaylock && systemctl suspend` which was then converted to `swaylock -f && systemctl suspend`.
So this PR just tries to fix this issue. I have tested it and it works well. Please check by yourself too.