### PR TITLE
Switch between rel workspaces, move windows to rel workspaces

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -90,6 +90,13 @@ bind = $mainMod, 8, workspace, 8
 bind = $mainMod, 9, workspace, 9
 bind = $mainMod, 0, workspace, 10
 
+# Switch workspaces relative to the active workspace with mainMod + CTRL + [←→]
+bind = $mainMod CTRL, right, workspace, r+1 
+bind = $mainMod CTRL, left, workspace, r-1
+
+# move to the first empty workspace instantly with mainMod + CTRL + [↓]
+bind = $mainMod CTRL, down, workspace, empty 
+
 # Resize windows
 binde = $mainMod SHIFT, right, resizeactive, 10 0
 binde = $mainMod SHIFT, left, resizeactive, -10 0
@@ -107,6 +114,10 @@ bind = $mainMod SHIFT, 7, movetoworkspace, 7
 bind = $mainMod SHIFT, 8, movetoworkspace, 8
 bind = $mainMod SHIFT, 9, movetoworkspace, 9
 bind = $mainMod SHIFT, 0, movetoworkspace, 10
+
+# Move active window to a relative workspace with mainMod + CTRL + ALT + [←→]
+bind = $mainMod CTRL ALT, right, movetoworkspace, r+1
+bind = $mainMod CTRL ALT, left, movetoworkspace, r-1
 
 # Move active window around current workspace with mainMod + SHIFT + CTRL [←→↑↓]
 bind = $mainMod SHIFT $CONTROL, left, movewindow, l


### PR DESCRIPTION
This PR adds what I find an essential element for keyboard users to fully enjoy the workspace experience and that is the ability to switch between relative workspaces and move windows between relative workspaces.

-  Switch to relative workspaces using `mainMod + CTRL +  [left, right]` 
   (functionality was present for mouse but missing for keyboard users)
-  Move windows between relative workspaces using `mainMod + CTRL + ALT +  [left, right]`    
  (could not use `mainMod + CTRL + shift + [left, right] `  as it is already bound to moving window inside a workspace)

and a tiny bit more
-  Switch to first empty workspace using `mainMod + CTRL +  [down] `
   (In case if anybody wants an empty workspace instantly without moving through all the workspaces one by one, although this workspace can be in the middle in the start or in the end, but it will do for now I think)

