### PR TITLE
feat: add trash management in terminal

### DIFF
--- a/Scripts/custom_apps.lst
+++ b/Scripts/custom_apps.lst
@@ -1,5 +1,6 @@
 #neovim
 #emote
+trash-cli-git
 steam
 gamemode
 #gamescope


### PR DESCRIPTION
Adding trash can in terminal for trash management & to prevent accidental deletion of files <br>
[trash-cli](https://github.com/andreafrancia/trash-cli) available in both:
[arch repo](https://archlinux.org/packages/extra/any/trash-cli/) <sup>***(Flagged out-of-date on 2023-09-24)***</sup> &
[trash-cli-git](https://aur.archlinux.org/packages/trash-cli-git)<sup>AUR</sup> <br>
usage: check [documentation](https://github.com/andreafrancia/trash-cli#usage)
it can also be automated: [how-to-auto-delete-files-older-that-30-days](https://github.com/andreafrancia/trash-cli#how-to-auto-delete-files-older-that-30-days)

Example usage:<br>
>`trash-list` makes it easy to check the files & directory inside the trash
>`trash-empty` empties trash can with confirmation (y/n)<br>

![listing contents of trash in terminal](https://github.com/prasanthrangan/hyprdots/assets/50130192/f3f17fdd-7542-4611-87b2-ca255e18143d)
![emptying trash can in terminal](https://github.com/prasanthrangan/hyprdots/assets/50130192/01a1a05d-4df4-4e01-9399-900dfe0eb5f4)
