### PR TITLE
Shortcut to open the system monitor (htop) and enable/disable waybar

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -14,6 +14,7 @@ $term = kitty
 $editor = code
 $file = dolphin
 $browser = firefox
+$sys_monitor = kitty htop
 
 # Window/Session actions
 bind = $mainMod, Q, exec, ~/.config/hypr/scripts/dontkillsteam.sh # killactive, kill the window on focus
@@ -24,12 +25,14 @@ bind = $mainMod, G, togglegroup, # toggle the window on focus to float
 bind = ALT, return, fullscreen, # toggle the window on focus to fullscreen
 bind = $mainMod, L, exec, swaylock # lock screen
 bind = $mainMod, backspace, exec, ~/.config/hypr/scripts/logoutlaunch.sh 1 # logout menu
+bind = $CONTROL, ESCAPE, exec, killall waybar || waybar # toggle waybar
 
 # Application shortcuts
 bind = $mainMod, T, exec, $term  # open terminal
 bind = $mainMod, E, exec, $file # open file manager
 bind = $mainMod, C, exec, $editor # open vscode
 bind = $mainMod, F, exec, $browser # open browser
+bind = $CONTROL SHIFT, ESCAPE, exec, $sys_monitor # open htop (system monitor)
 
 # Rofi is toggled on/off if you repeat the key presses
 bind = $mainMod, A, exec, pkill -x rofi || ~/.config/hypr/scripts/rofilaunch.sh d # launch desktop applications


### PR DESCRIPTION
These changes allow the user to quickly open the system monitor (htop) and enable/disable waybar