### PR TITLE
[Enhancement] Battery Notification +Error Handlers

### DIFF
--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -54,7 +54,7 @@ fn_notify () { # Send notification
     dunstify -a "Power" $1 -u $2 "$3" "$4" -p # Call the notify-send command with the provided arguments \$1 is the flags \$2 is the urgency \$3 is the title \$4 is the message
 }
 fn_percentage () { 
-                    if [[ "$battery_percentage" -ge "$unplug_charger_threshold" ]] &&  [[ "$battery_status" != "Discharging" ]]  && (( (battery_percentage - last_notified_percentage) >= $interval )); then if $verbose; then echo "Prompt:UNPLUG$battery_unplug_threshold $battery_status $battery_percentage" ; fi
+                    if [[ "$battery_percentage" -ge "$unplug_charger_threshold" ]] &&  [[ "$battery_status" != "Discharging" ]]  && (( (battery_percentage - last_notified_percentage) >= $interval )); then if $verbose; then echo "Prompt:UNPLUG: $battery_unplug_threshold $battery_status $battery_percentage" ; fi
                         fn_notify  "-t 5000 " "CRITICAL" "Battery Charged" "Battery is at $battery_percentage%. You can unplug the charger!"
                         last_notified_percentage=$battery_percentage
                     elif [[ "$battery_percentage" -le "$battery_critical_threshold" ]]; then
@@ -67,7 +67,7 @@ fn_percentage () {
                             sleep 1  
                         done
                         [ $count -eq 0 ] && fn_action
-                    elif [[ "$battery_percentage" -le "$battery_low_threshold" ]] && [[ "$battery_status" == "Discharging" ]] && (( (last_notified_percentage - battery_percentage) >= $interval )); then  if $verbose; then echo  "Prompt:LOW$battery_low_threshold $battery_status $battery_percentage" ; fi
+                    elif [[ "$battery_percentage" -le "$battery_low_threshold" ]] && [[ "$battery_status" == "Discharging" ]] && (( (last_notified_percentage - battery_percentage) >= $interval )); then  if $verbose; then echo  "Prompt:LOW: $battery_low_threshold $battery_status $battery_percentage" ; fi
                         fn_notify  "-t 5000 " "CRITICAL" "Battery Low" "Battery is at $battery_percentage%. Connect the charger."
                         last_notified_percentage=$battery_percentage
                     fi

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -52,7 +52,7 @@ fn_percentage () {
                         last_notified_percentage=$battery_percentage
                     fi
 }
-fn_action () {
+fn_action () { #handles the $execute command
                   count=$(( timer > $mnt ? timer :  $mnt )) # reset count
                   nohup $execute
 }

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -1,20 +1,27 @@
 #!/bin/bash
 in_range() { local num=$1 local min=$2 local max=$3 ;  [[ $num =~ ^[0-9]+$ ]] && (( num >= min && num <= max )) }
-mnc=5 mxc=20 mnl=20 mnu=50 mxl=50 mxu=100 mnt=60 mxt=1000 #Defaults
+mnc=5 mxc=80 mnl=20 mxl=50 mnu=80  mxu=100 mnt=60 mxt=1000 mnf=80 mxf=100 mnn=1 mxn=60 mni=1 mxi=10 verbose=false #Defaults Ranges
 while (( "$#" )); do  # Parse command-line arguments and defaults  
   case "$1" in
-"--critical"|"-c") if in_range "$2" $mnc $mxc; then battery_critical_threshold=$2 ; shift 2 ; else echo "Error: $1 must be a number between $mnc - $mxc." >&2 ; exit 1 ; fi;;
-"--low"|"-l") if in_range "$2" $mnl $mnu; then battery_low_threshold=$2 ; shift 2 ; else echo "Error: $1 must be a number between $mnl - $mnu." >&2 ; exit 1 ; fi;;
-"--unplug"|"-u") if in_range "$2" $mnu $mxu; then unplug_charger_threshold=$2 ; shift 2 ; else echo "Error: $1 must be a number between $mnu $mxu." >&2 ; exit 1 ; fi;;
-"--timer"|"-t") if in_range "$2" $mnt $mxt; then timer=$2 ; shift 2 ; else echo "Error: $1 must be a number between $mnt - $mxt." >&2 ; exit 1 ; fi;;
+"--full"|"-f") if in_range "$2" $mnf $mxf; then battery_full_threshold=$2 ; shift 2 ; else echo "$1 Error: Full Threshold must be $mnf - $mxf." >&2 ; exit 1 ; fi;;
+"--critical"|"-c") if in_range "$2" $mnc $mxc; then battery_critical_threshold=$2 ; shift 2 ; else echo "$1 ERROR: Critical Threshold must be $mnc - $mxc." >&2 ; exit 1 ; fi;;
+"--low"|"-l") if in_range "$2" $mnl $mnu; then battery_low_threshold=$2 ; shift 2 ; else echo "$1 ERROR: Low Threshold $mnl - $mnu." >&2 ; exit 1 ; fi;;
+"--unplug"|"-u") if in_range "$2" $mnu $mxu; then unplug_charger_threshold=$2 ; shift 2 ; else echo "$1 ERROR: Unplug Threshold must be $mnu $mxu." >&2 ; exit 1 ; fi;;
+"--timer"|"-t") if in_range "$2" $mnt $mxt; then timer=$2 ; shift 2 ; else echo "$1 ERROR: Timer must be $mnt - $mxt." >&2 ; exit 1 ; fi;;
+"--notify"|"-n") if in_range "$2" $mnn $mxn; then notify=$2 ; shift 2 ; else echo "$1 ERROR: Notify must be $mnn - $mxn in minutes." >&2 ; exit 1 ; fi;;
+"--interval"|"-i") if in_range "$2" $mni $mxi; then notify=$2 ; shift 2 ; else echo "$1 ERROR: Interval must be by $mni% - $mxi% intervals." >&2 ; exit 1 ; fi;;
+"--verbose"|"-v") verbose=true ; shift ;;
 "--execute"|"-e") execute=$2 ; shift 2 ;;
     *|"--help"|"-h")
       echo "Usage: $0 [options]"
-      echo "  --critical, -c    Set battery critical threshold (default: $mnc)"
-      echo "  --low, -l         Set battery low threshold (default: $mnl)"
-      echo "  --unplug, -u      Set unplug charger threshold (default: $mxu)"
-      echo "  --timer, -t       Set countdown timer (default: $mnt)"
-      echo "  --execute, -e     Set command/script to execute (default: systemctl suspend)"
+      echo "  --full, -f        Set battery full threshold (default: $mnf% percent)"
+      echo "  --critical, -c    Set battery critical threshold (default: $mnc% percent)"
+      echo "  --low, -l         Set battery low threshold (default: $mnl% percent)"
+      echo "  --unplug, -u      Set unplug charger threshold (default: $mxu% percent )"
+      echo "  --timer, -t       Set countdown timer (default: $mnt seconds)"
+      echo "  --interval, -i    Set notify interval  on LOW UNPLUG Status  (default: 2% percent)"
+      echo "  --notify, -n      Set notify interval for Battery Full Status  (default: 5 minutes)"
+      echo "  --execute, -e     Set command/script to execute if battery on critical threshold (default: systemctl suspend)"
       echo "  --help, -h        Show this help message
       Visit https://github.com/prasanthrangan/hyprdots for the Github Repo"
       exit 0
@@ -30,25 +37,24 @@ is_laptop() { # Check if the system is a laptop
     fi
 }
 fn_notify () { # Send notification
-    notify-send -t 5000 $1 -u $2 "$3" "$4" # Call the notify-send command with the provided arguments \$1 is the flags \$2 is the urgency \$3 is the title \$4 is the message
+    notify-send  $1 -u $2 "$3" "$4" # Call the notify-send command with the provided arguments \$1 is the flags \$2 is the urgency \$3 is the title \$4 is the message
 }
-fn_percentage () {
-                    if [[ "$battery_percentage" -ge "$unplug_charger_threshold" ]] &&  [[ "$battery_status" != "Discharging" ]]  && (( (battery_percentage - last_notified_percentage) >= 2 )); then
-                        fn_notify  "-r 10" "CRITICAL" "Battery Charged" "Battery is at $battery_percentage%. You can unplug the charger!"
+fn_percentage () { 
+                    if [[ "$battery_percentage" -ge "$unplug_charger_threshold" ]] &&  [[ "$battery_status" != "Discharging" ]]  && (( (battery_percentage - last_notified_percentage) >= $interval )); then
+                        fn_notify  "-t 5000 " "CRITICAL" "Battery Charged" "Battery is at $battery_percentage%. You can unplug the charger!"
                         last_notified_percentage=$battery_percentage
                     elif [[ "$battery_percentage" -le "$battery_critical_threshold" ]]; then
-                        count=$(( timer > $mnt ? timer :  $mnt )) # reset countstatus
+                        count=$(( timer > $mnt ? timer :  $mnt )) # reset count
                         while [ $count -gt 0 ] && [[ $battery_status == "Discharging"* ]]; do
                         for battery in /sys/class/power_supply/BAT*; do  battery_status=$(< "$battery/status") ; done
                         if [[ $battery_status != "Discharging" ]] ; then break ; fi
-                            fn_notify "-r 10" "CRITICAL" "Battery Critically Low" "$battery_percentage% is critically low. Device will execute $execute in $((count/60)):$((count%60)) ."
+                            fn_notify "-t 5000 -r 69 " "CRITICAL" "Battery Critically Low" "$battery_percentage% is critically low. Device will execute $execute in $((count/60)):$((count%60)) ."
                             count=$((count-1))
-                            sleep 1
-                            
+                            sleep 1  
                         done
                         [ $count -eq 0 ] && fn_action
-                    elif [[ "$battery_percentage" -le "$battery_low_threshold" ]] && [[ "$battery_status" == "Discharging" ]] && (( (last_notified_percentage - battery_percentage) >= 2 )); then
-                        fn_notify  "-r 10" "CRITICAL" "Battery Low" "Battery is at $battery_percentage%. Connect the charger."
+                    elif [[ "$battery_percentage" -le "$battery_low_threshold" ]] && [[ "$battery_status" == "Discharging" ]] && (( (last_notified_percentage - battery_percentage) >= $interval )); then
+                        fn_notify  "-t 5000 " "CRITICAL" "Battery Low" "Battery is at $battery_percentage%. Connect the charger."
                         last_notified_percentage=$battery_percentage
                     fi
 }
@@ -56,72 +62,100 @@ fn_action () { #handles the $execute command
                   count=$(( timer > $mnt ? timer :  $mnt )) # reset count
                   nohup $execute
 }
-fn_status () { # Handle the power supply status
-for battery in /sys/class/power_supply/BAT*; do  battery_status=$(< "$battery/status")  battery_percentage=$(< "$battery/capacity")
+
+fn_status () {
+if [ $battery_percentage -ge $battery_full_threshold ]; then battery_status="Full" ;fi
 case "$battery_status" in         # Handle the power supply status
                 "Discharging")
-                    if [[ "$prev_status" == *"Charging"* ]]; then
+                    if [[ "$prev_status" == *"Charging"* ]] || [[ "$prev_status" == "Full" ]] ; then 
                         prev_status=$battery_status
                         urgency=$([[ $battery_percentage -le "$battery_low_threshold" ]] && echo "CRITICAL" || echo "NORMAL")
-                        fn_notify   "-r 10" "$urgency" "Charger Plug OUT" "Battery is at $battery_percentage%."
+                        fn_notify   "-t 5000 -r 6996" "$urgency" "Charger Plug OUT" "Battery is at $battery_percentage%."
                     fi
                     fn_percentage 
                     ;;
                 "Not"*|"Charging") # Due to modifications of some devices Not Charging after reaching 99 or limits
-                    if [[ ! -f "/tmp/hyprdots.batterynotify.status.$battery_status-$$" ]] && [[ "$battery_status" == "Not"* ]] ; then
+                    if [[ ! -f "/tmp/hyprdots.batterynotify.status.$battery_status-$$" ]] && [[ "$battery_status" == "Not"* ]] ; then 
                     touch "/tmp/hyprdots.batterynotify.status.$battery_status-$$"
                     count=$(( timer > $mnt ? timer :  $mnt )) # reset count                    
                     echo "Status: '==>> "$battery_status" <<==' Device Reports Not Charging!,This may be device Specific errors."
-                    fn_notify  "-r 10" "CRITICAL" "Charger Plug In" "Battery is at $battery_percentage%."
+                    fn_notify  "-t 5000 -r 6996" "CRITICAL" "Charger Plug In" "Battery is at $battery_percentage%."
                     fi
-                    if [[ "$prev_status" == "Discharging" ]] || [[ "$prev_status" == "Not"* ]]; then
+                    if [[ "$prev_status" == "Discharging" ]] || [[ "$prev_status" == "Not"* ]] ; then
                         prev_status=$battery_status
                         count=$(( timer > $mnt ? timer :  $mnt )) # reset count
                         urgency=$([[ "$battery_percentage" -ge $unplug_charger_threshold ]] && echo "CRITICAL" || echo "NORMAL")
-                        fn_notify  "-r 10" "$urgency" "Charger Plug In" "Battery is at $battery_percentage%."
+                        fn_notify  "-t 5000 -r 6996" "$urgency" "Charger Plug In" "Battery is at $battery_percentage%."
                     fi
                     fn_percentage 
                     ;;
-                "Full")
-                    fn_notify  "-r 10" "CRITICAL" "Battery Full" "Please unplug your Charger"                    
-                    ;;
-                                    
+                "Full") 
+                    if [[ $battery_status != "Discharging" ]]; then
+                    now=$(date +%s) 
+                    if [[ "$prev_status" == *"Charging"* ]] || ((now - lt >= $((notify*60)) )); then
+                     fn_notify "-t 5000 " "CRITICAL" "Battery Full" "Please unplug your Charger"
+                    prev_status=$battery_status lt=$now
+                    fi
+                    fi
+                    ;;                                   
                     *)
-                    if [[ ! -f "/tmp/hyprdots.batterynotify.status.fallback.$battery_status-$$" ]]; then
+                    if [[ ! -f "/tmp/hyprdots.batterynotify.status.fallback.$battery_status-$$" ]]; then 
                     echo "Status: '==>> "$battery_status" <<==' Script on Fallback mode,Unknown power supply status.Please copy this line and raise an issue to the Github Repo.Also run 'ls /tmp/hyprdots.batterynotify' to see the list of lock files.*"
                     touch "/tmp/hyprdots.batterynotify.status.fallback.$battery_status-$$"
                     fi     
                     fn_percentage 
                     ;;
             esac
-        done
+}
+
+fn_status_change () { # Handle when status changes
+for battery in /sys/class/power_supply/BAT*; do  battery_status=$(< "$battery/status")  battery_percentage=$(< "$battery/capacity")
+   # Check if battery status or percentage has changed
+   if [ "$battery_status" != "$last_battery_status" ] || [ "$battery_percentage" != "$last_battery_percentage" ]; then last_battery_status=$battery_status last_battery_percentage=$battery_percentage
+if $verbose; then 
+cat << VERBOSE
+=============================================
+        Battery Status: $battery_status              
+        Battery Percentage: $battery_percentage      
+=============================================
+
+VERBOSE
+fi
+fn_percentage
+fn_status
+fi
+done
 }
 main() { # Main function
     if is_laptop; then
 rm -fr /tmp/hyprdots.batterynotify* # Cleaning the lock file
-battery_critical_threshold=${battery_critical_threshold:-$mnc} 
-unplug_charger_threshold=${unplug_charger_threshold:-$mxu}
-battery_low_threshold=${battery_low_threshold:-$mnl}
-timer=${timer:-$mnt}
+battery_full_threshold=${battery_full_threshold:-100} 
+battery_critical_threshold=${battery_critical_threshold:-10} 
+unplug_charger_threshold=${unplug_charger_threshold:-80}
+battery_low_threshold=${battery_low_threshold:-20}
+timer=${timer:-120}
+notify=${notify:-1140}
+interval=${interval:-2}
+
 execute=${execute:-"systemctl suspend"}
 cat <<  EOF
 Script is running... 
 Check $0 --help for options. 
 
-      Critical Battery Threshold: $battery_critical_threshold
-           Low Battery Threshold: $battery_low_threshold 
-        Unplug Charger Threshold: $unplug_charger_threshold  
+      STATUS      THRESHOLD    INTERVAL
+      Full        $battery_full_threshold          $notify Minutes  
+      Critical    $battery_critical_threshold           $timer Seconds then "$execute"
+      Low         $battery_low_threshold           $interval Percent
+      Unplug      $unplug_charger_threshold          $interval Percent
 
-If Battery is $battery_critical_threshold%, Device will execute $execute after $timer seconds. 
-
-If you have Errors Please Post an issue at https://github.com/prasanthrangan/hyprdots
 
 EOF
-    fn_status  # initiate the function
+if $verbose; then for line in "Verbose Mode is ON..." "" "" "" ""  ; do echo $line ; done;fi
+    fn_status_change  # initiate the function
     last_notified_percentage=$battery_percentage
     prev_status=$battery_status
 
-dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',path='$(upower -e | grep battery)'" 2> /dev/null | while read -r battery_status_change; do fn_status  ; done
+dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',path='$(upower -e | grep battery)'" 2> /dev/null | while read -r battery_status_change; do fn_status_change  ; done
     fi
 }
 main

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -98,6 +98,7 @@ case "$battery_status" in         # Handle the power supply status
 }
 main() { # Main function
     if is_laptop; then
+rm -fr /tmp/hyprdots.batterynotify* # Cleaning the lock file
 battery_critical_threshold=${battery_critical_threshold:-$mnc} 
 unplug_charger_threshold=${unplug_charger_threshold:-$mxu}
 battery_low_threshold=${battery_low_threshold:-$mnl}

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -67,7 +67,13 @@ case "$battery_status" in         # Handle the power supply status
                     fi
                     fn_percentage 
                     ;;
-                "Charging")                     
+                "Not"*|"Charging") # Due to modifications of some devices Not Charging after reaching 99 or limits
+                    if [[ ! -f "/tmp/hyprdots.batterynotify.status.$battery_status-$$" ]] && [[ "$battery_status" == "Not"* ]] ; then
+                    touch "/tmp/hyprdots.batterynotify.status.$battery_status-$$"
+                    count=$(( timer > $mnt ? timer :  $mnt )) # reset count                    
+                    echo "Status: '==>> "$battery_status" <<==' Device Reports Not Charging!,This may be device Specific errors.Please copy this line and raise an issue to the Github Repo.Also run 'ls /tmp/hyprdots.batterynotify' to see the list of lock files.*"
+                    fn_notify  "-r 10" "CRITICAL" "Charger Plug In" "Battery is at $battery_percentage%."
+                    fi
                     if [[ "$prev_status" == "Discharging" ]] || [[ "$prev_status" == "Not"* ]]; then
                         prev_status=$battery_status
                         count=$(( timer > $mnt ? timer :  $mnt )) # reset count
@@ -79,22 +85,7 @@ case "$battery_status" in         # Handle the power supply status
                 "Full")
                     fn_notify  "-r 10" "CRITICAL" "Battery Full" "Please unplug your Charger"                    
                     ;;
-                "Not charging"|"Not Charging"|*"Not"*)
-                    if [[ ! -f "/tmp/hyprdots.batterynotify.status.$battery_status-$$" ]]; then
-                    touch "/tmp/hyprdots.batterynotify.status.$battery_status-$$"
-                    count=$(( timer > $mnt ? timer :  $mnt )) # reset count                    
-                    echo "Status: '==>> "$battery_status" <<==' Device Reports Not Charging!,This may be device Specific errors.Please copy this line and raise an issue to the Github Repo.Also run 'ls /tmp/hyprdots.batterynotify' to see the list of lock files.*"
-                    fn_notify  "-r 10" "CRITICAL" "Charger Plug In" "Battery is at $battery_percentage%."
-                    else
-                    if [[ "$prev_status" == "Discharging" ]] || [[ "$prev_status" == "Charging" ]]; then
-                        prev_status=$battery_status
-                        count=$(( timer > $mnt ? timer :  $mnt )) # reset count
-                        urgency=$([[ "$battery_percentage" -ge $unplug_charger_threshold ]] && echo "CRITICAL" || echo "NORMAL")
-                        fn_notify  "-r 10" "$urgency" "Charger Plug In" "Battery is at $battery_percentage%."
-                    fi
-                    fi    
-                    fn_percentage                    
-                    ;;                                       
+                                    
                     *)
                     if [[ ! -f "/tmp/hyprdots.batterynotify.status.fallback.$battery_status-$$" ]]; then
                     echo "Status: '==>> "$battery_status" <<==' Script on Fallback mode,Unknown power supply status.Please copy this line and raise an issue to the Github Repo.Also run 'ls /tmp/hyprdots.batterynotify' to see the list of lock files.*"

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -71,7 +71,7 @@ case "$battery_status" in         # Handle the power supply status
                     if [[ ! -f "/tmp/hyprdots.batterynotify.status.$battery_status-$$" ]] && [[ "$battery_status" == "Not"* ]] ; then
                     touch "/tmp/hyprdots.batterynotify.status.$battery_status-$$"
                     count=$(( timer > $mnt ? timer :  $mnt )) # reset count                    
-                    echo "Status: '==>> "$battery_status" <<==' Device Reports Not Charging!,This may be device Specific errors.Please copy this line and raise an issue to the Github Repo.Also run 'ls /tmp/hyprdots.batterynotify' to see the list of lock files.*"
+                    echo "Status: '==>> "$battery_status" <<==' Device Reports Not Charging!,This may be device Specific errors."
                     fn_notify  "-r 10" "CRITICAL" "Charger Plug In" "Battery is at $battery_percentage%."
                     fi
                     if [[ "$prev_status" == "Discharging" ]] || [[ "$prev_status" == "Not"* ]]; then

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -82,7 +82,7 @@ if [[ $battery_percentage -ge $battery_full_threshold ]] && [ "$battery_status" 
  battery_status="Full" ;fi
 case "$battery_status" in         # Handle the power supply status
                 "Discharging") if $verbose; then echo "Case:$battery_status Level: $battery_percentage" ;fi
-                    if [[ "$prev_status" == *"Charging"* ]] || [[ "$prev_status" == "Full" ]] ; then 
+                    if [[ "$prev_status" == *"harging"* ]] || [[ "$prev_status" == "Full" ]] ; then 
                         prev_status=$battery_status
                         urgency=$([[ $battery_percentage -le "$battery_low_threshold" ]] && echo "CRITICAL" || echo "NORMAL")
                         fn_notify   "-t 5000 -r 54321 " "$urgency" "Charger Plug OUT" "Battery is at $battery_percentage%."

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -2,7 +2,7 @@
 is_number_in_range() { local num=$1 local min=$2 local max=$3 ;  [[ $num =~ ^[0-9]+$ ]] && (( num >= min && num <= max )) }
 # Parse command-line arguments
 
-while (( "$#" )); do  mnc=1 mxc=100 mxl=50 mxu=100 mnt=10 mxt=1000 mnu=50 mnl=20
+while (( "$#" )); do  mnc=1 mxc=20 mnl=20 mnu=50 mxl=50 mxu=100 mnt=10 mxt=1000  
   case "$1" in
     "--critical"|"-c")
       if is_number_in_range "$2" $mnc $mxc; then
@@ -55,16 +55,11 @@ while (( "$#" )); do  mnc=1 mxc=100 mxl=50 mxu=100 mnt=10 mxt=1000 mnu=50 mnl=20
       ;;
   esac
 done
-
-# Rest of your script
-
-
-
-
 is_laptop() { # Check if the system is a laptop
     if grep -q "Battery" /sys/class/power_supply/BAT*/type; then
         return 0  # It's a laptop
     else
+    echo "Cannot Detect a Battery. If this seems an error please report an issue to https://github.com/prasanthrangan/hyprdots."
         exit 0  # It's not a laptop
     fi
 }
@@ -148,9 +143,9 @@ case "$battery_status" in         # Handle the power supply status
 }
 main() { # Main function
     if is_laptop; then
-        battery_critical_threshold=${battery_critical_threshold:-5}
-    unplug_charger_threshold=${unplug_charger_threshold:-100}
-    battery_low_threshold=${battery_low_threshold:-10}
+        battery_critical_threshold=${battery_critical_threshold:-$mnc}
+    unplug_charger_threshold=${unplug_charger_threshold:-$mxu}
+    battery_low_threshold=${battery_low_threshold:-mnl}
     timer=${timer:-$mnt}
     execute=${execute:-"systemctl suspend"}
 cat <<  EOF

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -45,7 +45,6 @@ cat << VERBOSE
 =============================================
 
 
-
 VERBOSE
 fi
 }
@@ -54,7 +53,7 @@ fn_notify () { # Send notification
     notify-send -a "Power" $1 -u $2 "$3" "$4" -p # Call the notify-send command with the provided arguments \$1 is the flags \$2 is the urgency \$3 is the title \$4 is the message
 }
 fn_percentage () { 
-                    if [[ "$battery_percentage" -ge "$unplug_charger_threshold" ]] &&  [[ "$battery_status" != "Discharging" ]]  && (( (battery_percentage - last_notified_percentage) >= $interval )); then if $verbose; then for line in "Percent" "$battery_status" "$battery_percentage" "" ""  ; do echo $line ; done;fi
+                    if [[ "$battery_percentage" -ge "$unplug_charger_threshold" ]] &&  [[ "$battery_status" != "Discharging" ]]  && (( (battery_percentage - last_notified_percentage) >= $interval )); then if $verbose; then echo "Prompt:UNPLUG$battery_unplug_threshold $battery_status $battery_percentage" ; fi
                         fn_notify  "-t 5000 " "CRITICAL" "Battery Charged" "Battery is at $battery_percentage%. You can unplug the charger!"
                         last_notified_percentage=$battery_percentage
                     elif [[ "$battery_percentage" -le "$battery_critical_threshold" ]]; then
@@ -67,7 +66,7 @@ fn_percentage () {
                             sleep 1  
                         done
                         [ $count -eq 0 ] && fn_action
-                    elif [[ "$battery_percentage" -le "$battery_low_threshold" ]] && [[ "$battery_status" == "Discharging" ]] && (( (last_notified_percentage - battery_percentage) >= $interval )); then if $verbose; then for line in "Percent" "$battery_status" "$battery_percentage" "" ""  ; do echo $line ; done;fi
+                    elif [[ "$battery_percentage" -le "$battery_low_threshold" ]] && [[ "$battery_status" == "Discharging" ]] && (( (last_notified_percentage - battery_percentage) >= $interval )); then  if $verbose; then echo  "Prompt:LOW$battery_low_threshold $battery_status $battery_percentage" ; fi
                         fn_notify  "-t 5000 " "CRITICAL" "Battery Low" "Battery is at $battery_percentage%. Connect the charger."
                         last_notified_percentage=$battery_percentage
                     fi
@@ -81,7 +80,7 @@ fn_status () {
 if [[ $battery_percentage -ge $battery_full_threshold ]] && [ "$battery_status" == "Charging" ]; then echo "Full and $battery_status"
  battery_status="Full" ;fi
 case "$battery_status" in         # Handle the power supply status
-                "Discharging") if $verbose; then for line in "Action" "Case:$battery_status" "Level: $battery_percentage" "" ""  ; do echo $line ; done;fi
+                "Discharging") if $verbose; then echo "Case:$battery_status Level: $battery_percentage" ;fi
                     if [[ "$prev_status" == *"Charging"* ]] || [[ "$prev_status" == "Full" ]] ; then 
                         prev_status=$battery_status
                         urgency=$([[ $battery_percentage -le "$battery_low_threshold" ]] && echo "CRITICAL" || echo "NORMAL")
@@ -89,7 +88,7 @@ case "$battery_status" in         # Handle the power supply status
                     fi
                     fn_percentage 
                     ;;
-                "Not"*|"Charging") if $verbose; then for line in "Action" "Case:$battery_status" "Level: $battery_percentage" "" ""  ; do echo $line ; done;fi
+                "Not"*|"Charging") if $verbose; then echo "Case:$battery_status Level: $battery_percentage" ;fi
                 # Due to modifications of some devices Not Charging after reaching 99 or limits
                     #if [[ ! -f "/tmp/hyprdots.batterynotify.status.$battery_status-$$" ]] && [[ "$battery_status" == "Not"* ]] ; then 
                     #touch "/tmp/hyprdots.batterynotify.status.$battery_status-$$"
@@ -105,7 +104,7 @@ case "$battery_status" in         # Handle the power supply status
                     fi
                     fn_percentage 
                     ;;
-                "Full") if $verbose; then for line in "Action" "Case:$battery_status" "Level: $battery_percentage" "" ""  ; do echo $line ; done;fi
+                "Full") if $verbose; then echo "Case:$battery_status Level: $battery_percentage" ;fi
 
                     if [[ $battery_status != "Discharging" ]]; then
                     now=$(date +%s) 

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -12,14 +12,13 @@ while (( "$#" )); do  # Parse command-line arguments and defaults
 "--notify"|"-n") if in_range "$2" $mnn $mxn; then notify=$2 ; shift 2 ; else echo "$1 ERROR: Notify must be $mnn - $mxn in minutes." >&2 ; exit 1 ; fi;;
 "--interval"|"-i") if in_range "$2" $mni $mxi; then interval=$2 ; shift 2 ; else echo "$1 ERROR: Interval must be by $mni% - $mxi% intervals." >&2 ; exit 1 ; fi;;
 "--verbose"|"-v") verbose=true ; shift ;;
-"--undock"|"-on") undock=true ; shift ;;
-
+"--undock"|"on") undock=true ; shift ;;
 "--execute"|"-e") execute=$2 ; shift 2 ;;
 
     *|"--help"|"-h")
       echo "Usage: $0 [options]"
       echo "  --verbose, -v     Verbose Mode"
-      echo "  --undock, -on     Shows Battery Plug In/Out/Full Notification"
+      echo "  --undock, on     Shows Battery Plug In/Out/Full Notification"
       echo "  --full, -f        Set battery full threshold (default: 100% percent)"
       echo "  --critical, -c    Set battery critical threshold (default: 10% percent)"
       echo "  --low, -l         Set battery low threshold (default: 20% percent)"

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -15,13 +15,13 @@ while (( "$#" )); do  # Parse command-line arguments and defaults
 "--execute"|"-e") execute=$2 ; shift 2 ;;
     *|"--help"|"-h")
       echo "Usage: $0 [options]"
-      echo "  --full, -f        Set battery full threshold (default: $mnf% percent)"
-      echo "  --critical, -c    Set battery critical threshold (default: $mnc% percent)"
-      echo "  --low, -l         Set battery low threshold (default: $mnl% percent)"
-      echo "  --unplug, -u      Set unplug charger threshold (default: $mxu% percent )"
-      echo "  --timer, -t       Set countdown timer (default: $mnt seconds)"
-      echo "  --interval, -i    Set notify interval  on LOW UNPLUG Status  (default: 2% percent)"
-      echo "  --notify, -n      Set notify interval for Battery Full Status  (default: 5 minutes)"
+      echo "  --full, -f        Set battery full threshold (default: 100% percent)"
+      echo "  --critical, -c    Set battery critical threshold (default: 10% percent)"
+      echo "  --low, -l         Set battery low threshold (default: 20% percent)"
+      echo "  --unplug, -u      Set unplug charger threshold (default: 80% percent )"
+      echo "  --timer, -t       Set countdown timer (default: 120 seconds)"
+      echo "  --interval, -i    Set notify interval  on LOW UNPLUG Status  (default: 5% percent)"
+      echo "  --notify, -n      Set notify interval for Battery Full Status  (default: 1140 mins/ 1 day)"
       echo "  --execute, -e     Set command/script to execute if battery on critical threshold (default: systemctl suspend)"
       echo "  --help, -h        Show this help message
       Visit https://github.com/prasanthrangan/hyprdots for the Github Repo"

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
 # User Variables
-battery_critical_threshold=10     #? Set  Battery  Critical Limit to suspend
+battery_critical_threshold=10     #? Set  Battery  Critical Limit to suspend 
 battery_low_threshold=20    #? Set Battery Low Limit
 unplug_charger_threshold=80   #? Set Max Battery Status Warning
 countdown=300      #? Countdown timer ; if set to less than 60 defaults to 60 seconds
 action="suspend" #? will be appended to systemctl $action
-
 
 is_laptop() { # Check if the system is a laptop
     if grep -q "Battery" /sys/class/power_supply/BAT*/type; then
@@ -15,93 +14,89 @@ is_laptop() { # Check if the system is a laptop
         exit 0  # It's not a laptop
     fi
 }
-send_notification() { # Send notification
+fn_notify () { # Send notification
     notify-send -t 5000 $1 -u $2 "$3" "$4" # Call the notify-send command with the provided arguments \$1 is the flags \$2 is the urgency \$3 is the title \$4 is the message
 }
-check_battery() {  # Check battery status
-    echo $(cat "$1/status") $(< "$1/capacity")    # Read and echo the battery status and capacity
+fn_percentage () {
+                    if [[ "$battery_percentage" -ge "$unplug_charger_threshold" ]] && (( (battery_percentage - last_notified_percentage) >= 1 )); then
+                        fn_notify  "-r 10" "CRITICAL" "Battery Charged" "Battery is at $battery_percentage%. You can unplug the charger."
+                        last_notified_percentage=$battery_percentage
+                    elif [[ "$battery_percentage" -le "$battery_critical_threshold" ]]; then
+                        count=$(( countdown > 60 ? countdown : 60 )) # reset count
+                        while [ $count -gt 0 ] && [[ $battery_status == "Discharging"* ]]; do
+for battery in /sys/class/power_supply/BAT*; do  battery_status=$(< "$battery/status") ; done
+if [[ $battery_status != "Discharging" ]] ; then break ; fi
+                            fn_notify "-r 10" "CRITICAL" "Battery Critically Low" "$battery_percentage% is critically low. Device will $action in $((count/60)):$((count%60)) ."
+                            count=$((count-1))
+                            sleep 1
+                            #battery_status="Charging"
+                        done
+                        [ $count -eq 0 ] && fn_action
+                    elif [[ "$battery_percentage" -le "$battery_low_threshold" ]] && (( (last_notified_percentage - battery_percentage) >= 1 )); then
+                        fn_notify  "-r 10" "CRITICAL" "Battery Low" "Battery is at $battery_percentage%. Connect the charger."
+                        last_notified_percentage=$battery_percentage
+                    fi
 }
-handle_action () {
-count=$(( $countdown > 60 ? $countdown : 60 )) # reset count
+fn_action () {
+count=$(( countdown > 60 ? countdown : 60 )) # reset count
 nohup systemctl $action
 }
-
-# Handle the power supply status
-handle_power_supply() {
-for battery in /sys/class/power_supply/BAT*; do
-        read -r battery_status battery_percentage <<< $(check_battery $battery)
-case $battery_status in         # Handle the power supply status
+fn_status () { # Handle the power supply status
+for battery in /sys/class/power_supply/BAT*; do  battery_status=$(< "$battery/status")  battery_percentage=$(< "$battery/capacity")
+#echo $battery_status $battery_percentage
+case "$battery_status" in         # Handle the power supply status
                 "Discharging")
                     if [[ "$prev_status" == "Charging" ]]; then
                         prev_status=$battery_status
                         urgency=$([[ $battery_percentage -le "$battery_low_threshold" ]] && echo "CRITICAL" || echo "NORMAL")
-                        send_notification  "-r 10" "$urgency" "Charger Plug OUT" "Battery is at $battery_percentage%."
+                        fn_notify   "-r 10" "$urgency" "Charger Plug OUT" "Battery is at $battery_percentage%."
                     fi
-                    # Check if battery is below critical threshold
-                    if [[ "$battery_percentage" -le "$battery_critical_threshold" ]]; then
-                        count=$(( $countdown > 60 ? $countdown : 60 ))
-                        while [ $count -gt 0 ] && [[ "$(check_battery $battery)" != "Charging"* ]]; do
-                            send_notification "-r 10" "CRITICAL" "Battery Critically Low" "$battery_percentage% is critically low. Device will $action in $((count/60)):$((count%60)) ."
-                            count=$((count-1))
-                            sleep 1
-                        done
-                        if [ $count -eq 0 ]; then
-                             handle_action
-                        fi
-                    elif [[ "$battery_percentage" -le "$battery_low_threshold" ]] && (( (last_notified_percentage - battery_percentage) >= 1 )); then
-                        send_notification "-r 10" "CRITICAL" "Battery Low" "Battery is at $battery_percentage%. Connect the charger."
-                        last_notified_percentage=$battery_percentage
-                    fi
+                    fn_percentage 
                     ;;
                 "Charging")                     
-                    if [[ "$prev_status" == "Discharging" ]]; then
+                    if [[ "$prev_status" == "Discharging" ]] || [[ "$prev_status" == "Not"* ]]; then
                         prev_status=$battery_status
-                        count=$(( $countdown > 60 ? $countdown : 60 )) # reset count
+                        count=$(( countdown > 60 ? countdown : 60 )) # reset count
                         urgency=$([[ "$battery_percentage" -ge $unplug_charger_threshold ]] && echo "CRITICAL" || echo "NORMAL")
-                        send_notification "-r 10" "$urgency" "Charger Plug In" "Battery is at $battery_percentage%."
+                        fn_notify  "-r 10" "$urgency" "Charger Plug In" "Battery is at $battery_percentage%."
                     fi
-                    if [[ "$battery_percentage" -ge $unplug_charger_threshold ]] && (( (battery_percentage - last_notified_percentage) >= 1 )); then
-                        send_notification "-r 10" "CRITICAL" "Battery Charged" "Battery is at $battery_percentage%. You can unplug the charger."
-                        last_notified_percentage=$battery_percentage
-                    fi
+                    fn_percentage 
                     ;;
                 "Full")
-                    send_notification "-r 10" "CRITICAL" "Battery Full" "Please unplug your Charger"
+                    fn_notify  "-r 10" "CRITICAL" "Battery Full" "Please unplug your Charger"                    
                     ;;
-                "Not Charging")
-                    send_notification "-r 10" "CRITICAL" "Device Not Charging!" "Please Check your Charger or Device Temperature"
-                    ;;                                       
-                    *)
-                   if [[ ! -f "/tmp/hyprdots.batterynotify.fallback.status.$battery_status-$$" ]]; then
-                    echo "Status: '==>> "$battery_status" <<==' Script on Fallback mode,Unknown power supply status.Please copy this line and raise an issue to the Github Repo.Also run 'ls /tmp/hyprdots.batterynotify' to see the list of lock files.*"
-                    touch "/tmp/hyprdots.batterynotify.fallback.status.$battery_status-$$"
-                    fi               
-                    #send_notification "-r 10" "CRITICAL" "Unknown power supply status." "Please raise an issue to the Github Repo(You will only see this once after boot)"
-                    if [[ "$battery_percentage" -ge $unplug_charger_threshold ]] && (( (battery_percentage - last_notified_percentage) >= 1 )); then
-                        send_notification "-r 10" "CRITICAL" "Battery Charged" "Battery is at $battery_percentage%. You can unplug the charger."
-                        last_notified_percentage=$battery_percentage
-                    elif [[ "$battery_percentage" -le "$battery_critical_threshold" ]]; then
-                        count=$(( $countdown > 60 ? $countdown : 60 ))
-                        while [ $count -gt 0 ] && [[ "$(check_battery $battery)" != "Charging"* ]]; do
-                            send_notification "-r 10" "CRITICAL" "Battery Critically Low" "$battery_percentage% is critically low. Device will $action in $((count/60)):$((count%60)) ."
-                            count=$((count-1))
-                            sleep 1
-                        done
-                        [ $count -eq 0 ] && handle_action
-                    elif [[ "$battery_percentage" -le "$battery_low_threshold" ]] && (( (last_notified_percentage - battery_percentage) >= 1 )); then
-                        send_notification "-r 10" "CRITICAL" "Battery Low" "Battery is at $battery_percentage%. Connect the charger."
-                        last_notified_percentage=$battery_percentage
+                "Not charging"|"Not Charging"|"Not")
+                    if [[ ! -f "/tmp/hyprdots.batterynotify.status.$battery_status-$$" ]]; then
+                    touch "/tmp/hyprdots.batterynotify.status.$battery_status-$$"
+                    count=$(( countdown > 60 ? countdown : 60 )) # reset count                    
+                    echo "Status: '==>> "$battery_status" <<==' Device Reports Not Charging!,This may be device Specific errors.Please copy this line and raise an issue to the Github Repo.Also run 'ls /tmp/hyprdots.batterynotify' to see the list of lock files.*"
+                    fn_notify  "-r 10" "CRITICAL" "Charger Plug In" "Battery is at $battery_percentage%."
+                    else
+                    if [[ "$prev_status" == "Discharging" ]] || [[ "$prev_status" == "Charging" ]]; then
+                        prev_status=$battery_status
+                        count=$(( countdown > 60 ? countdown : 60 )) # reset count
+                        urgency=$([[ "$battery_percentage" -ge $unplug_charger_threshold ]] && echo "CRITICAL" || echo "NORMAL")
+                        fn_notify  "-r 10" "$urgency" "Charger Plug In" "Battery is at $battery_percentage%."
                     fi
+                    fi    
+                    fn_percentage                    
+                    ;;                                       
+                    "*")
+                    if [[ ! -f "/tmp/hyprdots.batterynotify.status.fallback.$battery_status-$$" ]]; then
+                    echo "Status: '==>> "$battery_status" <<==' Script on Fallback mode,Unknown power supply status.Please copy this line and raise an issue to the Github Repo.Also run 'ls /tmp/hyprdots.batterynotify' to see the list of lock files.*"
+                    touch "/tmp/hyprdots.batterynotify.status.fallback.$battery_status-$$"
+                    fi     
+                    fn_percentage 
                     ;;
             esac
         done
 }
 main() { # Main function
     if is_laptop; then
-        handle_power_supply # initiate the function
+        fn_status  # initiate the function
         last_notified_percentage=$battery_percentage
         prev_status=$battery_status
-        dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',path='$(upower -e | grep battery)'" 2> /dev/null | while read -r battery_status_change; do handle_power_supply ; done
+        dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',path='$(upower -e | grep battery)'" 2> /dev/null | while read -r battery_status_change; do fn_status  ; done
     fi
 }
 main

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -143,8 +143,8 @@ battery_critical_threshold=${battery_critical_threshold:-10}
 unplug_charger_threshold=${unplug_charger_threshold:-80}
 battery_low_threshold=${battery_low_threshold:-20}
 timer=${timer:-120}
-notify=${notify:-1}
-interval=${interval:-2}
+notify=${notify:-1140}
+interval=${interval:-5}
 
 execute=${execute:-"systemctl suspend"}
 cat <<  EOF

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -114,7 +114,7 @@ case "$battery_status" in         # Handle the power supply status
                     if [[ $battery_status != "Discharging" ]]; then
                     now=$(date +%s) 
                     if [[ "$prev_status" == *"harging"* ]] || ((now - lt >= $((notify*60)) )); then
-                     fn_notify "-t 5000 -r 54321" "CRITICAL" "Battery Full   (Click to EXIT)" "Please unplug your Charger"
+                     fn_notify "-t 5000 -r 54321" "CRITICAL" "Battery Full" "Please unplug your Charger"
                     prev_status=$battery_status lt=$now
                     fi
                     fi

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -10,7 +10,7 @@ while (( "$#" )); do  # Parse command-line arguments and defaults
 "--unplug"|"-u") if in_range "$2" $mnu $mxu; then unplug_charger_threshold=$2 ; shift 2 ; else echo "$1 ERROR: Unplug Threshold must be $mnu $mxu." >&2 ; exit 1 ; fi;;
 "--timer"|"-t") if in_range "$2" $mnt $mxt; then timer=$2 ; shift 2 ; else echo "$1 ERROR: Timer must be $mnt - $mxt." >&2 ; exit 1 ; fi;;
 "--notify"|"-n") if in_range "$2" $mnn $mxn; then notify=$2 ; shift 2 ; else echo "$1 ERROR: Notify must be $mnn - $mxn in minutes." >&2 ; exit 1 ; fi;;
-"--interval"|"-i") if in_range "$2" $mni $mxi; then notify=$2 ; shift 2 ; else echo "$1 ERROR: Interval must be by $mni% - $mxi% intervals." >&2 ; exit 1 ; fi;;
+"--interval"|"-i") if in_range "$2" $mni $mxi; then interval=$2 ; shift 2 ; else echo "$1 ERROR: Interval must be by $mni% - $mxi% intervals." >&2 ; exit 1 ; fi;;
 "--verbose"|"-v") verbose=true ; shift ;;
 "--execute"|"-e") execute=$2 ; shift 2 ;;
     *|"--help"|"-h")
@@ -51,7 +51,7 @@ fi
 }
 fn_notify () { # Send notification
 
-    notify-send -a "Power" $1 -u $2 "$3" "$4" -p # Call the notify-send command with the provided arguments \$1 is the flags \$2 is the urgency \$3 is the title \$4 is the message
+    dunstify -a "Power" $1 -u $2 "$3" "$4" -p # Call the notify-send command with the provided arguments \$1 is the flags \$2 is the urgency \$3 is the title \$4 is the message
 }
 fn_percentage () { 
                     if [[ "$battery_percentage" -ge "$unplug_charger_threshold" ]] &&  [[ "$battery_status" != "Discharging" ]]  && (( (battery_percentage - last_notified_percentage) >= $interval )); then if $verbose; then echo "Prompt:UNPLUG$battery_unplug_threshold $battery_status $battery_percentage" ; fi

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 in_range() { local num=$1 local min=$2 local max=$3 ;  [[ $num =~ ^[0-9]+$ ]] && (( num >= min && num <= max )) }
-mnc=5 mxc=20 mnl=20 mnu=50 mxl=50 mxu=100 mnt=60 mxt=1000 mnf=80 mxf=100 mnn=1 mxn=60 mni=1 mxi=10 #Defaults Ranges
+mnc=5 mxc=80 mnl=20 mxl=50 mnu=80  mxu=100 mnt=60 mxt=1000 mnf=80 mxf=100 mnn=1 mxn=60 mni=1 mxi=10 verbose=false #Defaults Ranges
 while (( "$#" )); do  # Parse command-line arguments and defaults  
   case "$1" in
-"--full"|"-f") if in_range "$2" $mnf $mxf; then battery_full_threshold=$2 ; shift 2 ; else echo "Error: $1 must be a number between $mnf - $mxf." >&2 ; exit 1 ; fi;;
-"--critical"|"-c") if in_range "$2" $mnc $mxc; then battery_critical_threshold=$2 ; shift 2 ; else echo "Error: $1 must be a number between $mnc - $mxc." >&2 ; exit 1 ; fi;;
-"--low"|"-l") if in_range "$2" $mnl $mnu; then battery_low_threshold=$2 ; shift 2 ; else echo "Error: $1 must be a number between $mnl - $mnu." >&2 ; exit 1 ; fi;;
-"--unplug"|"-u") if in_range "$2" $mnu $mxu; then unplug_charger_threshold=$2 ; shift 2 ; else echo "Error: $1 must be a number between $mnu $mxu." >&2 ; exit 1 ; fi;;
-"--timer"|"-t") if in_range "$2" $mnt $mxt; then timer=$2 ; shift 2 ; else echo "Error: $1 must be a number between $mnt - $mxt." >&2 ; exit 1 ; fi;;
-"--notify"|"-n") if in_range "$2" $mnn $mxn; then notify=$2 ; shift 2 ; else echo "Error: $1 must be $mnn - $mxn in minutes." >&2 ; exit 1 ; fi;;
-"--interval"|"-i") if in_range "$2" $mni $mxi; then notify=$2 ; shift 2 ; else echo "Error: $1 must be by $mni% - $mxi% intervals." >&2 ; exit 1 ; fi;;
-
+"--full"|"-f") if in_range "$2" $mnf $mxf; then battery_full_threshold=$2 ; shift 2 ; else echo "$1 Error: Full Threshold must be $mnf - $mxf." >&2 ; exit 1 ; fi;;
+"--critical"|"-c") if in_range "$2" $mnc $mxc; then battery_critical_threshold=$2 ; shift 2 ; else echo "$1 ERROR: Critical Threshold must be $mnc - $mxc." >&2 ; exit 1 ; fi;;
+"--low"|"-l") if in_range "$2" $mnl $mnu; then battery_low_threshold=$2 ; shift 2 ; else echo "$1 ERROR: Low Threshold $mnl - $mnu." >&2 ; exit 1 ; fi;;
+"--unplug"|"-u") if in_range "$2" $mnu $mxu; then unplug_charger_threshold=$2 ; shift 2 ; else echo "$1 ERROR: Unplug Threshold must be $mnu $mxu." >&2 ; exit 1 ; fi;;
+"--timer"|"-t") if in_range "$2" $mnt $mxt; then timer=$2 ; shift 2 ; else echo "$1 ERROR: Timer must be $mnt - $mxt." >&2 ; exit 1 ; fi;;
+"--notify"|"-n") if in_range "$2" $mnn $mxn; then notify=$2 ; shift 2 ; else echo "$1 ERROR: Notify must be $mnn - $mxn in minutes." >&2 ; exit 1 ; fi;;
+"--interval"|"-i") if in_range "$2" $mni $mxi; then notify=$2 ; shift 2 ; else echo "$1 ERROR: Interval must be by $mni% - $mxi% intervals." >&2 ; exit 1 ; fi;;
+"--verbose"|"-v") verbose=true ; shift ;;
 "--execute"|"-e") execute=$2 ; shift 2 ;;
     *|"--help"|"-h")
       echo "Usage: $0 [options]"
@@ -39,22 +39,22 @@ is_laptop() { # Check if the system is a laptop
 fn_notify () { # Send notification
     notify-send  $1 -u $2 "$3" "$4" # Call the notify-send command with the provided arguments \$1 is the flags \$2 is the urgency \$3 is the title \$4 is the message
 }
-fn_percentage () {
+fn_percentage () { 
                     if [[ "$battery_percentage" -ge "$unplug_charger_threshold" ]] &&  [[ "$battery_status" != "Discharging" ]]  && (( (battery_percentage - last_notified_percentage) >= $interval )); then
-                        fn_notify  "-t 5000 -r 10" "CRITICAL" "Battery Charged" "Battery is at $battery_percentage%. You can unplug the charger!"
+                        fn_notify  "-t 5000 " "CRITICAL" "Battery Charged" "Battery is at $battery_percentage%. You can unplug the charger!"
                         last_notified_percentage=$battery_percentage
                     elif [[ "$battery_percentage" -le "$battery_critical_threshold" ]]; then
                         count=$(( timer > $mnt ? timer :  $mnt )) # reset count
                         while [ $count -gt 0 ] && [[ $battery_status == "Discharging"* ]]; do
                         for battery in /sys/class/power_supply/BAT*; do  battery_status=$(< "$battery/status") ; done
                         if [[ $battery_status != "Discharging" ]] ; then break ; fi
-                            fn_notify "-t 5000 -r 10" "CRITICAL" "Battery Critically Low" "$battery_percentage% is critically low. Device will execute $execute in $((count/60)):$((count%60)) ."
+                            fn_notify "-t 5000 -r 69 " "CRITICAL" "Battery Critically Low" "$battery_percentage% is critically low. Device will execute $execute in $((count/60)):$((count%60)) ."
                             count=$((count-1))
                             sleep 1  
                         done
                         [ $count -eq 0 ] && fn_action
                     elif [[ "$battery_percentage" -le "$battery_low_threshold" ]] && [[ "$battery_status" == "Discharging" ]] && (( (last_notified_percentage - battery_percentage) >= $interval )); then
-                        fn_notify  "-t 5000 -r 10" "CRITICAL" "Battery Low" "Battery is at $battery_percentage%. Connect the charger."
+                        fn_notify  "-t 5000 " "CRITICAL" "Battery Low" "Battery is at $battery_percentage%. Connect the charger."
                         last_notified_percentage=$battery_percentage
                     fi
 }
@@ -62,15 +62,15 @@ fn_action () { #handles the $execute command
                   count=$(( timer > $mnt ? timer :  $mnt )) # reset count
                   nohup $execute
 }
-fn_status () { # Handle the power supply status
-for battery in /sys/class/power_supply/BAT*; do  battery_status=$(< "$battery/status")  battery_percentage=$(< "$battery/capacity")
-if [ $battery_percentage -eq $battery_full_threshold ]; then battery_status="Full" ;fi
+
+fn_status () {
+if [ $battery_percentage -ge $battery_full_threshold ]; then battery_status="Full" ;fi
 case "$battery_status" in         # Handle the power supply status
                 "Discharging")
                     if [[ "$prev_status" == *"Charging"* ]] || [[ "$prev_status" == "Full" ]] ; then 
                         prev_status=$battery_status
                         urgency=$([[ $battery_percentage -le "$battery_low_threshold" ]] && echo "CRITICAL" || echo "NORMAL")
-                        fn_notify   "-t 5000 -r 10" "$urgency" "Charger Plug OUT" "Battery is at $battery_percentage%."
+                        fn_notify   "-t 5000 -r 6996" "$urgency" "Charger Plug OUT" "Battery is at $battery_percentage%."
                     fi
                     fn_percentage 
                     ;;
@@ -79,13 +79,13 @@ case "$battery_status" in         # Handle the power supply status
                     touch "/tmp/hyprdots.batterynotify.status.$battery_status-$$"
                     count=$(( timer > $mnt ? timer :  $mnt )) # reset count                    
                     echo "Status: '==>> "$battery_status" <<==' Device Reports Not Charging!,This may be device Specific errors."
-                    fn_notify  "-t 5000 -r 10" "CRITICAL" "Charger Plug In" "Battery is at $battery_percentage%."
+                    fn_notify  "-t 5000 -r 6996" "CRITICAL" "Charger Plug In" "Battery is at $battery_percentage%."
                     fi
                     if [[ "$prev_status" == "Discharging" ]] || [[ "$prev_status" == "Not"* ]] ; then
                         prev_status=$battery_status
                         count=$(( timer > $mnt ? timer :  $mnt )) # reset count
                         urgency=$([[ "$battery_percentage" -ge $unplug_charger_threshold ]] && echo "CRITICAL" || echo "NORMAL")
-                        fn_notify  "-t 5000 -r 10" "$urgency" "Charger Plug In" "Battery is at $battery_percentage%."
+                        fn_notify  "-t 5000 -r 6996" "$urgency" "Charger Plug In" "Battery is at $battery_percentage%."
                     fi
                     fn_percentage 
                     ;;
@@ -93,7 +93,7 @@ case "$battery_status" in         # Handle the power supply status
                     if [[ $battery_status != "Discharging" ]]; then
                     now=$(date +%s) 
                     if [[ "$prev_status" == *"Charging"* ]] || ((now - lt >= $((notify*60)) )); then
-                     fn_notify "-t 5000 -r 69" "CRITICAL" "Battery Full" "Please unplug your Charger"
+                     fn_notify "-t 5000 " "CRITICAL" "Battery Full" "Please unplug your Charger"
                     prev_status=$battery_status lt=$now
                     fi
                     fi
@@ -106,17 +106,35 @@ case "$battery_status" in         # Handle the power supply status
                     fn_percentage 
                     ;;
             esac
-        done
+}
+
+fn_status_change () { # Handle when status changes
+for battery in /sys/class/power_supply/BAT*; do  battery_status=$(< "$battery/status")  battery_percentage=$(< "$battery/capacity")
+   # Check if battery status or percentage has changed
+   if [ "$battery_status" != "$last_battery_status" ] || [ "$battery_percentage" != "$last_battery_percentage" ]; then last_battery_status=$battery_status last_battery_percentage=$battery_percentage
+if $verbose; then 
+cat << VERBOSE
+=============================================
+        Battery Status: $battery_status              
+        Battery Percentage: $battery_percentage      
+=============================================
+
+VERBOSE
+fi
+fn_percentage
+fn_status
+fi
+done
 }
 main() { # Main function
     if is_laptop; then
 rm -fr /tmp/hyprdots.batterynotify* # Cleaning the lock file
-battery_full_threshold=${battery_full_threshold:-$mxf} 
-battery_critical_threshold=${battery_critical_threshold:-$mnc} 
-unplug_charger_threshold=${unplug_charger_threshold:-$mxu}
-battery_low_threshold=${battery_low_threshold:-$mnl}
-timer=${timer:-$mnt}
-notify=${notify:-5}
+battery_full_threshold=${battery_full_threshold:-100} 
+battery_critical_threshold=${battery_critical_threshold:-10} 
+unplug_charger_threshold=${unplug_charger_threshold:-80}
+battery_low_threshold=${battery_low_threshold:-20}
+timer=${timer:-120}
+notify=${notify:-1140}
 interval=${interval:-2}
 
 execute=${execute:-"systemctl suspend"}
@@ -124,26 +142,20 @@ cat <<  EOF
 Script is running... 
 Check $0 --help for options. 
 
-    |  Status    |  Threshold
-    |  Full      | $battery_full_threshold
-    |  Critical  | $battery_critical_threshold
-    |  Low       | $battery_low_threshold 
-    | Unplug     | $unplug_charger_threshold  
+      STATUS      THRESHOLD    INTERVAL
+      Full        $battery_full_threshold          $notify Minutes  
+      Critical    $battery_critical_threshold           $timer Seconds then "$execute"
+      Low         $battery_low_threshold           $interval Percent
+      Unplug      $unplug_charger_threshold          $interval Percent
 
-!!! Notification interval for Low and Unplug Percentage is $interval Percent(%).
-
-!!! Notification interval for Battery Full / $battery_full_threshold% is $notify minutes.
-
-!!! If Battery is $battery_critical_threshold%, Device will execute $execute after $timer seconds. 
-
-If you have Errors Please Post an issue at https://github.com/prasanthrangan/hyprdots
 
 EOF
-    fn_status  # initiate the function
+if $verbose; then for line in "Verbose Mode is ON..." "" "" "" ""  ; do echo $line ; done;fi
+    fn_status_change  # initiate the function
     last_notified_percentage=$battery_percentage
     prev_status=$battery_status
 
-dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',path='$(upower -e | grep battery)'" 2> /dev/null | while read -r battery_status_change; do fn_status  ; done
+dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',path='$(upower -e | grep battery)'" 2> /dev/null | while read -r battery_status_change; do fn_status_change  ; done
     fi
 }
 main

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -139,8 +139,8 @@ main() { # Main function
     if is_laptop; then
 rm -fr /tmp/hyprdots.batterynotify* # Cleaning the lock file
 battery_full_threshold=${battery_full_threshold:-100} 
-battery_critical_threshold=${battery_critical_threshold:-70} 
-unplug_charger_threshold=${unplug_charger_threshold:-100}
+battery_critical_threshold=${battery_critical_threshold:-10} 
+unplug_charger_threshold=${unplug_charger_threshold:-80}
 battery_low_threshold=${battery_low_threshold:-20}
 timer=${timer:-120}
 notify=${notify:-1}

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -1,11 +1,65 @@
 #!/bin/bash
+is_number_in_range() { local num=$1 local min=$2 local max=$3 ;  [[ $num =~ ^[0-9]+$ ]] && (( num >= min && num <= max )) }
+# Parse command-line arguments
 
-# User Variables
-battery_critical_threshold=10     #? Set  Battery  Critical Limit to suspend 
-battery_low_threshold=20    #? Set Battery Low Limit
-unplug_charger_threshold=80   #? Set Max Battery Status Warning
-countdown=300      #? Countdown timer ; if set to less than 60 defaults to 60 seconds
-action="suspend" #? will be appended to systemctl $action
+while (( "$#" )); do mnc=1 mxc=50 mxl=80 mxu=100 mnt=100 mxt=1000 mnu=$mxl mnl=$mxc
+  case "$1" in
+    "--critical"|"-c")
+      if is_number_in_range "$2" $mnc $mxc; then
+        battery_critical_threshold=$2
+        shift 2
+      else
+        echo "Error: $1 must be a number between $mnc - $mxc." >&2
+        exit 1
+      fi
+;;
+    "--low"|"-l")
+      if is_number_in_range "$2" $mnl $mnu; then
+        battery_low_threshold=$2
+        shift 2
+      else
+        echo "Error: $1 must be a number between $mnl - $mnu." >&2
+        exit 1
+      fi
+      ;;
+
+    "--unplug"|"-u")
+      if is_number_in_range "$2" $mnu $mxu; then
+        unplug_charger_threshold=$2
+        shift 2
+      else
+        echo "Error: $1 must be a number between $mnu $mxu." >&2
+        exit 1
+      fi
+      ;;
+    "--timer"|"-t")
+      if is_number_in_range "$2" $mnt $mxt; then
+        countdown=$2
+        shift 2
+      else
+        echo "Error: $1 must be a number between $mnt - $mxt." >&2
+        exit 1
+      fi
+      ;;
+
+"--execute"|"-e") execute=$2 ; shift 2 ;;
+    *|"--help"|"-h")
+      echo "Usage: $0 [options]"
+      echo "  --critical, -c    Set battery critical threshold (default: 5)"
+      echo "  --low, -l         Set battery low threshold (default: 10)"
+      echo "  --unplug, -u      Set unplug charger threshold (default: 100)"
+      echo "  --timer, -t       Set countdown timer (default: 120)"
+      echo "  --execute, -e     Set action to execute (default: suspend)"
+      echo "  --help, -h        Show this help message"
+      exit 0
+      ;;
+  esac
+done
+
+# Rest of your script
+
+
+
 
 is_laptop() { # Check if the system is a laptop
     if grep -q "Battery" /sys/class/power_supply/BAT*/type; then
@@ -22,11 +76,11 @@ fn_percentage () {
                         fn_notify  "-r 10" "CRITICAL" "Battery Charged" "Battery is at $battery_percentage%. You can unplug the charger."
                         last_notified_percentage=$battery_percentage
                     elif [[ "$battery_percentage" -le "$battery_critical_threshold" ]]; then
-                        count=$(( countdown > 60 ? countdown : 60 )) # reset count
+                        count=$(( timer > 120 ? timer : 120 )) # reset countstatus
                         while [ $count -gt 0 ] && [[ $battery_status == "Discharging"* ]]; do
-for battery in /sys/class/power_supply/BAT*; do  battery_status=$(< "$battery/status") ; done
-if [[ $battery_status != "Discharging" ]] ; then break ; fi
-                            fn_notify "-r 10" "CRITICAL" "Battery Critically Low" "$battery_percentage% is critically low. Device will $action in $((count/60)):$((count%60)) ."
+                        for battery in /sys/class/power_supply/BAT*; do  battery_status=$(< "$battery/status") ; done
+                        if [[ $battery_status != "Discharging" ]] ; then break ; fi
+                            fn_notify "-r 10" "CRITICAL" "Battery Critically Low" "$battery_percentage% is critically low. Device will execute $execute in $((count/60)):$((count%60)) ."
                             count=$((count-1))
                             sleep 1
                             #battery_status="Charging"
@@ -38,15 +92,16 @@ if [[ $battery_status != "Discharging" ]] ; then break ; fi
                     fi
 }
 fn_action () {
-count=$(( countdown > 60 ? countdown : 60 )) # reset count
-nohup systemctl $action
+count=$(( timer > 120 ? timer : 120 )) # reset count
+nohup systemctl $execute
 }
 fn_status () { # Handle the power supply status
 for battery in /sys/class/power_supply/BAT*; do  battery_status=$(< "$battery/status")  battery_percentage=$(< "$battery/capacity")
+#battery_status="Not Charging"
 #echo $battery_status $battery_percentage
 case "$battery_status" in         # Handle the power supply status
                 "Discharging")
-                    if [[ "$prev_status" == "Charging" ]]; then
+                    if [[ "$prev_status" == *"Charging"* ]]; then
                         prev_status=$battery_status
                         urgency=$([[ $battery_percentage -le "$battery_low_threshold" ]] && echo "CRITICAL" || echo "NORMAL")
                         fn_notify   "-r 10" "$urgency" "Charger Plug OUT" "Battery is at $battery_percentage%."
@@ -56,7 +111,7 @@ case "$battery_status" in         # Handle the power supply status
                 "Charging")                     
                     if [[ "$prev_status" == "Discharging" ]] || [[ "$prev_status" == "Not"* ]]; then
                         prev_status=$battery_status
-                        count=$(( countdown > 60 ? countdown : 60 )) # reset count
+                        count=$(( timer > 120 ? timer : 120 )) # reset count
                         urgency=$([[ "$battery_percentage" -ge $unplug_charger_threshold ]] && echo "CRITICAL" || echo "NORMAL")
                         fn_notify  "-r 10" "$urgency" "Charger Plug In" "Battery is at $battery_percentage%."
                     fi
@@ -65,23 +120,23 @@ case "$battery_status" in         # Handle the power supply status
                 "Full")
                     fn_notify  "-r 10" "CRITICAL" "Battery Full" "Please unplug your Charger"                    
                     ;;
-                "Not charging"|"Not Charging"|"Not")
+                "Not charging"|"Not Charging"|*"Not"*)
                     if [[ ! -f "/tmp/hyprdots.batterynotify.status.$battery_status-$$" ]]; then
                     touch "/tmp/hyprdots.batterynotify.status.$battery_status-$$"
-                    count=$(( countdown > 60 ? countdown : 60 )) # reset count                    
+                    count=$(( timer > 120 ? timer : 120 )) # reset count                    
                     echo "Status: '==>> "$battery_status" <<==' Device Reports Not Charging!,This may be device Specific errors.Please copy this line and raise an issue to the Github Repo.Also run 'ls /tmp/hyprdots.batterynotify' to see the list of lock files.*"
                     fn_notify  "-r 10" "CRITICAL" "Charger Plug In" "Battery is at $battery_percentage%."
                     else
                     if [[ "$prev_status" == "Discharging" ]] || [[ "$prev_status" == "Charging" ]]; then
                         prev_status=$battery_status
-                        count=$(( countdown > 60 ? countdown : 60 )) # reset count
+                        count=$(( timer > 120 ? timer : 120 )) # reset count
                         urgency=$([[ "$battery_percentage" -ge $unplug_charger_threshold ]] && echo "CRITICAL" || echo "NORMAL")
                         fn_notify  "-r 10" "$urgency" "Charger Plug In" "Battery is at $battery_percentage%."
                     fi
                     fi    
                     fn_percentage                    
                     ;;                                       
-                    "*")
+                    *)
                     if [[ ! -f "/tmp/hyprdots.batterynotify.status.fallback.$battery_status-$$" ]]; then
                     echo "Status: '==>> "$battery_status" <<==' Script on Fallback mode,Unknown power supply status.Please copy this line and raise an issue to the Github Repo.Also run 'ls /tmp/hyprdots.batterynotify' to see the list of lock files.*"
                     touch "/tmp/hyprdots.batterynotify.status.fallback.$battery_status-$$"
@@ -93,10 +148,29 @@ case "$battery_status" in         # Handle the power supply status
 }
 main() { # Main function
     if is_laptop; then
-        fn_status  # initiate the function
-        last_notified_percentage=$battery_percentage
-        prev_status=$battery_status
-        dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',path='$(upower -e | grep battery)'" 2> /dev/null | while read -r battery_status_change; do fn_status  ; done
+        battery_critical_threshold=${battery_critical_threshold:-5}
+    unplug_charger_threshold=${unplug_charger_threshold:-100}
+    battery_low_threshold=${battery_low_threshold:-10}
+    timer=${timer:-120}
+    execute=${execute:-"systemctl suspend"}
+cat <<  EOF
+Script is running... 
+Check $0 --help for options. 
+
+      Critical Battery Threshold: $battery_critical_threshold
+           Low Battery Threshold: $battery_low_threshold 
+        Unplug Charger Threshold: $unplug_charger_threshold  
+
+Device will execute $execute after $timer seconds. 
+
+If you have Errors Please Post an issue at https://github.com/prasanthrangan/hyprdots
+
+EOF
+
+fn_status  # initiate the function
+    last_notified_percentage=$battery_percentage
+    prev_status=$battery_status
+dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',path='$(upower -e | grep battery)'" 2> /dev/null | while read -r battery_status_change; do fn_status  ; done
     fi
 }
 main

--- a/Configs/.config/hypr/scripts/batterynotify.sh
+++ b/Configs/.config/hypr/scripts/batterynotify.sh
@@ -2,7 +2,7 @@
 is_number_in_range() { local num=$1 local min=$2 local max=$3 ;  [[ $num =~ ^[0-9]+$ ]] && (( num >= min && num <= max )) }
 # Parse command-line arguments
 
-while (( "$#" )); do mnc=1 mxc=50 mxl=80 mxu=100 mnt=100 mxt=1000 mnu=$mxl mnl=$mxc
+while (( "$#" )); do mnc=1 mxc=20 mxl=50 mxu=100 mnt=100 mxt=1000 mnu=50 mnl=20
   case "$1" in
     "--critical"|"-c")
       if is_number_in_range "$2" $mnc $mxc; then
@@ -161,7 +161,7 @@ Check $0 --help for options.
            Low Battery Threshold: $battery_low_threshold 
         Unplug Charger Threshold: $unplug_charger_threshold  
 
-Device will execute $execute after $timer seconds. 
+If Battery is $battery_critical_threshold%, Device will execute $execute after $timer seconds. 
 
 If you have Errors Please Post an issue at https://github.com/prasanthrangan/hyprdots
 


### PR DESCRIPTION
Continuation for  #414 
Discussion on Issue #411 

+ Non-intrusive Notification :bow:
+ Acts like the old script but prompts every 5% instead of per 5 minutes. (Upon reaching threshold) Stops if interval < 5.
+ Appending "on" "--dock" will Give Plug In/Out/Full
+ TUI
+ Error handling report on terminal 
+ Default for Battery full notification interval is set to 1 day.
+ Verbose mode for Debugging. 
+ Defaults on Screenshot. 
+ Should Fix If Device reports "Not" "Not charging" "Not Charging" or "Not"*


-- The script is too elaborate and could/should be refactored further. 


![image](https://github.com/prasanthrangan/hyprdots/assets/53417443/bb30ce68-7620-4cbc-867a-f8bc86690873)