### PR TITLE
added script to launch users preferred system monitor.

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -14,7 +14,6 @@ $term = kitty
 $editor = code
 $file = dolphin
 $browser = firefox
-$sys_monitor = kitty htop
 
 # Window/Session actions
 bind = $mainMod, Q, exec, ~/.config/hypr/scripts/dontkillsteam.sh # killactive, kill the window on focus
@@ -32,7 +31,7 @@ bind = $mainMod, T, exec, $term  # open terminal
 bind = $mainMod, E, exec, $file # open file manager
 bind = $mainMod, C, exec, $editor # open vscode
 bind = $mainMod, F, exec, $browser # open browser
-bind = $CONTROL SHIFT, ESCAPE, exec, $sys_monitor # open htop (system monitor)
+bind = $CONTROL SHIFT, ESCAPE, exec, ~/.config/hypr/scripts/sysmonlaunch.sh  # open htop/btop if installed or default to top (system monitor)
 
 # Rofi is toggled on/off if you repeat the key presses
 bind = $mainMod, A, exec, pkill -x rofi || ~/.config/hypr/scripts/rofilaunch.sh d # launch desktop applications

--- a/Configs/.config/hypr/scripts/sysmonlaunch.sh
+++ b/Configs/.config/hypr/scripts/sysmonlaunch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Define the list of commands to check in order of preference
 commands_to_check=("htop" "btop" "top")

--- a/Configs/.config/hypr/scripts/sysmonlaunch.sh
+++ b/Configs/.config/hypr/scripts/sysmonlaunch.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Define the list of commands to check in order of preference
+commands_to_check=("htop" "btop" "top")
+
+# Determine the terminal emulator to use
+term=$(cat $HOME/.config/hypr/keybindings.conf | grep ^'$term' | cut -d '=' -f2)
+
+# Try to execute the first available command in the specified terminal emulator
+for command in "${commands_to_check[@]}"; do
+    if command -v "$command" &> /dev/null; then
+        $term -e "$command"
+        break  # Exit the loop if the command executed successfully
+    fi
+done


### PR DESCRIPTION
This fork stems from a comment i made in #416 regarding a keybind to open a htop. 

I'm not completely against how this was done its just my personal opinion that if we are setting a keybind to open an application we should be making sure that application is being installed (added to the package list) other wise users may see the update press the keybind and then log an issue when the application does not open. 

To combat this i've whipped up a quick script to check if a user has one of the following [htop,btop,top] and open that in the default terminal set in the keybindings.conf. 
Tests i've run are as follows : 
 - Checked keybind with htop installed - htop opens in kitty
- Checked keybind with btop installed - btop opens in kitty
- Checked with neither htop/btop installed - Top opens in kitty
- Checked with both htop and btop installed - htop opens as its first in the list.

Please let me know if there are any issues.