### PR TITLE
Waybar Persistent Workspaces update -- Deprecated value removed 

### DIFF
--- a/Configs/.config/waybar/modules/workspaces.jsonc
+++ b/Configs/.config/waybar/modules/workspaces.jsonc
@@ -1,18 +1,9 @@
     "hyprland/workspaces": {
         "disable-scroll": true,
         "all-outputs": true,
+        "active-only": false,
         "on-click": "activate",
-        "persistent_workspaces": {
-            "1": [],
-            "2": [],
-            "3": [],
-            "4": [],
-            "5": [],
-            "6": [],
-            "7": [],
-            "8": [],
-            "9": [],
-            "10": []
+        "persistent-workspaces": {
+            "1": []
         }
     },
-


### PR DESCRIPTION
Fixed waybar

*Note: Latest waybar updates sucks. Its tapping 1-3 cores at 100% -- I'm going to downgrade for the time being but I wanted this to be fixed for the updates coming

![231103_09h01m08s_screenshot](https://github.com/prasanthrangan/hyprdots/assets/132922589/aa6d6724-93c2-4e22-b2ac-0793cb9099eb)

This is fixed in [0.9.24](https://github.com/Alexays/Waybar/releases/tag/0.9.24)