### PR TITLE
add hyprpicker-git to use grimblast --freeze

### DIFF
--- a/Scripts/custom_hypr.lst
+++ b/Scripts/custom_hypr.lst
@@ -24,6 +24,7 @@ swww
 swaylock-effects-git
 wlogout
 grimblast-git
+hyprpicker-git
 slurp
 swappy
 cliphist


### PR DESCRIPTION
I noticed the screenshot script (mainMod + P) does not freeze the screen when used. After some searching, I realized that hyprpicker-git needs to be installed in order for grimblast's --freeze option to work.

Thank you so much for creating hyprdots!