### PR TITLE
Reuse the cached Wallpaper

### DIFF
--- a/Scripts/restore_cfg.sh
+++ b/Scripts/restore_cfg.sh
@@ -61,7 +61,7 @@ do
     done
 
 done
-
+cp -r $BkpDir/.config/swww/.cache $HOME/.config/swww
 touch ${HOME}/.config/hypr/monitors.conf
 touch ${HOME}/.config/hypr/userprefs.conf
 


### PR DESCRIPTION
My system can't handle it anymore haha(But maybe not just my system). The constant updating and caching wallpapers makes my system too hot and takes up a lot of time to complete.

This is the shortest way I know to conserve the cache without configuring git. 

But please Tell me what checks we need to avoid errors. Or this approach is not good and there is a better way. 


For context: 
I fork the repo then On the fork, I added the cache folder so that it will be imported on ./restore.sh but by doing this like I said I should fork the repo or git add .../.cache which is not very intuitive for others, and sometimes git reports conflicts.


![231104_21h36m17s_screenshot](https://github.com/prasanthrangan/hyprdots/assets/53417443/b544fef0-a891-41f2-ac8f-3894d7769c47)
