### PR TITLE
fix(eza): fix `ls` dirs suggestions

### DIFF
--- a/Configs/.zshrc
+++ b/Configs/.zshrc
@@ -128,10 +128,10 @@ function in {
     fi
 }
 
-alias  l='eza -l  --icons' # long list
-alias ls='eza -1  --icons' # short list
-alias ll='eza -la --icons' # long list all
-alias ld='eza -lD --icons' # long list dirs
+alias  l='eza -l  --icons=auto' # long list
+alias ls='eza -1  --icons=auto' # short list
+alias ll='eza -la --icons=auto' # long list all
+alias ld='eza -lD --icons=auto' # long list dirs
 alias un='sudo pacman -Rns' # uninstall package
 alias up='sudo pacman -Syu' # update system/package/aur
 alias pl='pacman -Qs' # list installed package


### PR DESCRIPTION
Brings back the directories that are suggested by the list commands.