### PR TITLE
Enable numlock in hyprland.conf

### DIFF
--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -68,7 +68,7 @@ env = MOZ_ENABLE_WAYLAND,1
 input {
     kb_layout = us
     follow_mouse = 1
-
+    numlock_by_default = true
     touchpad {
         natural_scroll = no
     }


### PR DESCRIPTION
Enabled numlock by default. I don't know if it's a bug, or a feature, but everytime a workspace is switched the numlock is disabled and has to be enabled again manually.