### PR TITLE
Default : No Persistent Workspaces 

### DIFF
--- a/Configs/.config/waybar/modules/workspaces.jsonc
+++ b/Configs/.config/waybar/modules/workspaces.jsonc
@@ -1,9 +1,8 @@
-    "hyprland/workspaces": {
-        "disable-scroll": true,
-        "all-outputs": true,
-        "active-only": false,
-        "on-click": "activate",
-        "persistent-workspaces": {
-            "1": []
-        }
-    },
+"hyprland/workspaces": {
+    "disable-scroll": true,
+    "all-outputs": true,
+    "active-only": false,
+    "on-click": "activate",
+    "persistent-workspaces": {
+    }
+},


### PR DESCRIPTION
Is this okay? I have this case that I thought my workspace 1 had an active window. So can we remove any persistent workspaces?  
 I usually use a laptop to swipe and I find this slightly annoying hehe. If  You guys want a home workspace maybe we could implement 1 soon. 