### PR TITLE
Fn Check Dependency

### DIFF
--- a/Configs/.config/hypr/scripts/globalcontrol.sh
+++ b/Configs/.config/hypr/scripts/globalcontrol.sh
@@ -47,3 +47,14 @@ get_aurhlpr()
         aurhlpr="paru"
     fi
 }
+
+check(){
+    local Pkg_Dep=$(for PkgIn in "$@"; do ! pkg_installed $PkgIn && echo "$PkgIn"; done)
+
+if [ -n "$Pkg_Dep" ]; then echo -e "$0 Dependencies:\n$Pkg_Dep"
+    read -p "ENTER to install  (Other key: Cancel): " ans
+    if [ -z "$ans" ]; then get_aurhlpr ; $aurhlpr -S $Pkg_Dep
+    else echo "Skipping installation of packages" ;exit 1
+    fi
+fi
+}


### PR DESCRIPTION
Maybe This can be useful for future scripts, in case the user just uses ``` ./install.sh -r ```.  
I can only think of #435 

Usage: 

source ```  ~/.config/hypr/scripts/globalcontrol.sh ```
then
``` 
#Dependency check
check pkg1 pkg2 pkg3 
``` 

