### PR TITLE
feat: theme selector from current

### DIFF
--- a/Configs/.config/hypr/scripts/swwwallselect.sh
+++ b/Configs/.config/hypr/scripts/swwwallselect.sh
@@ -30,10 +30,11 @@ r_override="element{border-radius:${elem_border}px;} listview{columns:6;spacing:
 
 
 # launch rofi menu
+currentWall=`basename $fullPath`
 RofiSel=$( find "${wallPath}" -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) -exec basename {} \; | sort | while read rfile
 do
     echo -en "$rfile\x00icon\x1f${cacheDir}/${gtkTheme}/${rfile}\n"
-done | rofi -dmenu -theme-str "${r_override}" -config "${RofiConf}")
+done | rofi -dmenu -theme-str "${r_override}" -config "${RofiConf}" -select "${currentWall}")
 
 
 # apply wallpaper

--- a/Configs/.config/hypr/scripts/themeselect.sh
+++ b/Configs/.config/hypr/scripts/themeselect.sh
@@ -24,7 +24,7 @@ do
     thm=`echo $line | cut -d '|' -f 2`
     wal=`echo $line | awk -F '/' '{print $NF}'`
     echo -en "$thm\x00icon\x1f$cacheDir/${thm}/${wal}\n"
-done | rofi -dmenu -theme-str "${r_override}" -config $RofiConf)
+done | rofi -dmenu -theme-str "${r_override}" -config $RofiConf -select "${gtkTheme}")
 
 
 # apply theme


### PR DESCRIPTION
When selecting a theme or wallpaper the rofi selector always start at the first item. I found it more intuitive to have it start at the currently applied theme/wallpaper