### PR TITLE
Added tooltip functionality to spotify widget

### DIFF
--- a/Configs/.config/waybar/modules/mediaplayer.py
+++ b/Configs/.config/waybar/modules/mediaplayer.py
@@ -61,12 +61,13 @@ class PlayerManager:
     def get_players(self) -> List[Player]:
         return self.manager.props.players
 
-    def write_output(self, text, player):
+    def write_output(self, text, player, tooltip):
         logger.debug(f"Writing output: {text}")
 
         output = {"text": text,
                   "class": "custom-" + player.props.player_name,
-                  "alt": player.props.player_name}
+                  "alt": player.props.player_name,
+                  "tooltip": tooltip}
 
         sys.stdout.write(json.dumps(output) + "\n")
         sys.stdout.flush()
@@ -118,7 +119,7 @@ class PlayerManager:
             track_info = f"{artist} - {title}"
         else:
             track_info = title
-
+        tooltip = track_info
         if track_info:
             if player.props.status == "Playing":
                 track_info = " " + track_info
@@ -127,7 +128,7 @@ class PlayerManager:
         # only print output if no other player is playing
         current_playing = self.get_first_playing_player()
         if current_playing is None or current_playing.props.player_name == player.props.player_name:
-            self.write_output(track_info, player)
+            self.write_output(track_info, player, tooltip)
         else:
             logger.debug(f"Other player {current_playing.props.player_name} is playing, skipping")
 

--- a/Configs/.config/waybar/modules/spotify.jsonc
+++ b/Configs/.config/waybar/modules/spotify.jsonc
@@ -8,6 +8,7 @@
 	"on-scroll-up": "~/.config/hypr/scripts/spotifyvolumecontrol.sh up",
 	"on-scroll-down": "~/.config/hypr/scripts/spotifyvolumecontrol.sh down",
 	"max-length": 25,
-        "escape": true
+        "escape": true,
+        "tooltip": true
     },
 


### PR DESCRIPTION
## Changes:
- Modified `write_output()` function in `mediaplayer.py` to take a tooltip argument
- Added tooltip functionality to spotify widget to show the full title and artist that is playing

Changes that I made are minimal. If there is anything specific you want me to fix please let me know here :)