### PR TITLE
Minor change

### DIFF
--- a/Scripts/custom_hypr.lst
+++ b/Scripts/custom_hypr.lst
@@ -16,7 +16,7 @@ qt6-wayland
 qt5-quickcontrols
 qt5-quickcontrols2
 qt5-graphicaleffects
-hyprland-git
+hyprland
 dunst
 rofi-lbonn-wayland-git
 waybar


### PR DESCRIPTION
Changed the repo to the official version instead of git
```
hyprland-git --> hyprland
```
**Why?** - hyprland-git can't get installed, so the whole install script breaks at this part.
It's just a minor change that people don't get confused and can install everything without problems.