### PR TITLE
Relocate Cached Directory

### DIFF
--- a/Configs/.config/hypr/scripts/globalcontrol.sh
+++ b/Configs/.config/hypr/scripts/globalcontrol.sh
@@ -5,7 +5,7 @@ EnableWallDcol=0
 ConfDir="$HOME/.config"
 CloneDir="$HOME/Hyprdots"
 ThemeCtl="$ConfDir/hypr/theme.ctl"
-cacheDir="$ConfDir/swww/.cache"
+cacheDir="$HOME/.cache/Hyprdots/swww/"
 
 # theme var
 gtkTheme=`gsettings get org.gnome.desktop.interface gtk-theme | sed "s/'//g"`

--- a/Scripts/create_cache.sh
+++ b/Scripts/create_cache.sh
@@ -19,7 +19,7 @@ fi
 # set variables
 ctlFile="$HOME/.config/hypr/theme.ctl"
 ctlLine=`grep '^1|' $ctlFile`
-export cacheDir="$HOME/.config/swww/.cache"
+export cacheDir="$HOME/.cache/Hyprdots/swww/"
 
 # evaluate options
 while getopts "fc" option ; do

--- a/Scripts/restore_cfg.sh
+++ b/Scripts/restore_cfg.sh
@@ -18,6 +18,12 @@ if [ ! -f "${ThemeOverride}restore_cfg.lst" ] || [ ! -d "${CfgDir}" ] ; then
     exit 1
 fi
 
+if [ -d "$HOME/.config/swww/.cache/" ]; then #? Temporary support.
+    mkdir -p $HOME/.cache/Hyprdots/swww/
+    cp -r $HOME/.config/swww/.cache/* $HOME/.cache/Hyprdots/swww/
+    mv $HOME/.config/swww/.cache/ $HOME/.config/swww/.cache.deprecated/
+fi
+
 BkpDir="${HOME}/.config/$(date +'cfg_%y%m%d_%Hh%Mm%Ss')"
 
 if [ -d $BkpDir ] ; then


### PR DESCRIPTION
Title: Relocate .cached directory to ./.cache/Hyprdots/swww

Description:

This pull request aims to relocate the .cached directory to a new location under ~/.cache/Hyprdots/swww/. The rationale behind this change is to improve the efficiency of managing the dots like updating the configs. It is especially beneficial for those who might not know that they could disable the backup flag in the ./restore_cfg.lst.

Adding a few lines just to skip the cache is tedious, and with these changes, I hope the restore part of the script will not take much time and CPU power.

Changes:

Set its value to the new location: 
cacheDir="$HOME/.cache/Hyprdots/swww/" ($ConfDir/hypr/scripts/global**.sh)
export cacheDir="$HOME/.cache/Hyprdots/swww/"  (./create_cache.sh)
Added a line in ./restore_cfg.sh to manage these changes for users who will update soon.

Request:

I would appreciate everyone's opinion regarding these changes, especially if they might introduce any breaking changes.

