### PR TITLE
Use `XDG` Base Directory variables where possible

### DIFF
--- a/Configs/.config/hypr/scripts/cliphist.sh
+++ b/Configs/.config/hypr/scripts/cliphist.sh
@@ -9,8 +9,8 @@ roconf="~/.config/rofi/clipboard.rasi"
 x_offset=-15   #* Cursor spawn position on clipboard
 y_offset=210   #* To point the Cursor to the 1st and 2nd latest word
 #!base on $HOME/.config/rofi/clipboard.rasi 
-clip_h=$(cat $HOME/.config/rofi/clipboard.rasi | awk '/window {/,/}/'  | awk '/height:/ {print $2}' | awk -F "%" '{print $1}')
-clip_w=$(cat $HOME/.config/rofi/clipboard.rasi | awk '/window {/,/}/'  | awk '/width:/ {print $2}' | awk -F "%" '{print $1}')
+clip_h=$(cat "${XDG_CONFIG_HOME:-$HOME/.config}/rofi/clipboard.rasi" | awk '/window {/,/}/'  | awk '/height:/ {print $2}' | awk -F "%" '{print $1}')
+clip_w=$(cat "${XDG_CONFIG_HOME:-$HOME/.config}/rofi/clipboard.rasi" | awk '/window {/,/}/'  | awk '/width:/ {print $2}' | awk -F "%" '{print $1}')
 #clip_h=55 #! Modify limits for size of the Clipboard
 #clip_w=20 #! This values are transformed per cent(100)
 #? Monitor resolution , scale and rotation 

--- a/Configs/.config/hypr/scripts/gamelauncher.sh
+++ b/Configs/.config/hypr/scripts/gamelauncher.sh
@@ -3,13 +3,13 @@
 # set variables
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-ThemeSet="$HOME/.config/hypr/themes/theme.conf"
-RofiConf="$HOME/.config/rofi/steam/gamelauncher_${1}.rasi"
+ThemeSet="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/themes/theme.conf"
+RofiConf="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/steam/gamelauncher_${1}.rasi"
 
 
 # set steam library
-SteamLib="$HOME/.local/share/Steam/config/libraryfolders.vdf"
-SteamThumb="$HOME/.local/share/Steam/appcache/librarycache"
+SteamLib="${XDG_DATA_HOME:-$HOME/.local/share}/Steam/config/libraryfolders.vdf"
+SteamThumb="${XDG_DATA_HOME:-$HOME/.local/share}/Steam/appcache/librarycache"
 
 if [ ! -f $SteamLib ] || [ ! -d $SteamThumb ] || [ ! -f $RofiConf ] ; then
     dunstify "t1" -a "Steam library not found!" -r 91190 -t 2200

--- a/Configs/.config/hypr/scripts/globalcontrol.sh
+++ b/Configs/.config/hypr/scripts/globalcontrol.sh
@@ -2,7 +2,7 @@
 
 # wallpaper var
 EnableWallDcol=0
-ConfDir="$HOME/.config"
+ConfDir="${XDG_CONFIG_HOME:-$HOME/.config}"
 CloneDir="$HOME/Hyprdots"
 ThemeCtl="$ConfDir/hypr/theme.ctl"
 cacheDir="$ConfDir/swww/.cache"

--- a/Configs/.config/hypr/scripts/logoutlaunch.sh
+++ b/Configs/.config/hypr/scripts/logoutlaunch.sh
@@ -10,8 +10,8 @@ fi
 # set file variables
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-wLayout="$HOME/.config/wlogout/layout_$1"
-wlTmplt="$HOME/.config/wlogout/style_$1.css"
+wLayout="${XDG_CONFIG_HOME:-$HOME/.config}/wlogout/layout_$1"
+wlTmplt="${XDG_CONFIG_HOME:-$HOME/.config}/wlogout/style_$1.css"
 
 if [ ! -f $wLayout ] || [ ! -f $wlTmplt ] ; then
     echo "ERROR: Config $1 not found..."

--- a/Configs/.config/hypr/scripts/rofiselect.sh
+++ b/Configs/.config/hypr/scripts/rofiselect.sh
@@ -3,9 +3,9 @@
 # set variables
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-RofiConf="$HOME/.config/rofi/themeselect.rasi"
-RofiStyle="$HOME/.config/rofi/styles"
-Rofilaunch="$HOME/.config/rofi/config.rasi"
+RofiConf="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/themeselect.rasi"
+RofiStyle="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/styles"
+Rofilaunch="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/config.rasi"
 
 
 # scale for monitor x res

--- a/Configs/.config/hypr/scripts/screenshot.sh
+++ b/Configs/.config/hypr/scripts/screenshot.sh
@@ -6,7 +6,7 @@ fi
 
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-swpy_dir="$HOME/.config/swappy"
+swpy_dir="${XDG_CONFIG_HOME:-$HOME/.config}/swappy"
 save_dir="${2:-$XDG_PICTURES_DIR/Screenshots}"
 save_file=$(date +'%y%m%d_%Hh%Mm%Ss_screenshot.png')
 temp_screenshot="/tmp/screenshot.png"

--- a/Configs/.config/hypr/scripts/sddmwall.sh
+++ b/Configs/.config/hypr/scripts/sddmwall.sh
@@ -2,7 +2,7 @@
 
 sddmback="/usr/share/sddm/themes/corners/backgrounds/bg.png"
 sddmconf="/usr/share/sddm/themes/corners/theme.conf"
-slnkwall="$HOME/.config/swww/wall.set"
+slnkwall="${XDG_CONFIG_HOME:-$HOME/.config}/swww/wall.set"
 
 if [ "$(getfacl -p /home/${USER} | grep user:sddm | awk '{print substr($0,length)}')" != "x" ] ; then
     echo "granting sddm execution access to /home/${USER}..."

--- a/Configs/.config/hypr/scripts/swwwallbash.sh
+++ b/Configs/.config/hypr/scripts/swwwallbash.sh
@@ -4,7 +4,7 @@
 
 export ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-dcoDir="$HOME/.config/hypr/wallbash"
+dcoDir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/wallbash"
 input_wall="$1"
 export cacheImg=$(basename "${input_wall}")
 

--- a/Configs/.config/hypr/scripts/swwwallpaper.sh
+++ b/Configs/.config/hypr/scripts/swwwallpaper.sh
@@ -72,9 +72,9 @@ Wall_Set()
 
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-wallSet="$HOME/.config/swww/wall.set"
-wallBlr="$HOME/.config/swww/wall.blur"
-wallRfi="$HOME/.config/swww/wall.rofi"
+wallSet="${XDG_CONFIG_HOME:-$HOME/.config}/swww/wall.set"
+wallBlr="${XDG_CONFIG_HOME:-$HOME/.config}/swww/wall.blur"
+wallRfi="${XDG_CONFIG_HOME:-$HOME/.config}/swww/wall.rofi"
 ctlLine=$(grep '^1|' ${ThemeCtl})
 
 if [ `echo $ctlLine | wc -l` -ne "1" ] ; then
@@ -89,8 +89,8 @@ wallPath=$(dirname "$fullPath")
 mapfile -d '' Wallist < <(find ${wallPath} -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) -print0 | sort -z)
 
 if [ ! -f "$fullPath" ] ; then
-    if [ -d "$HOME/.config/swww/$curTheme" ] ; then
-        wallPath="$HOME/.config/swww/$curTheme"
+    if [ -d "${XDG_CONFIG_HOME:-$HOME/.config}/swww/$curTheme" ] ; then
+        wallPath="${XDG_CONFIG_HOME:-$HOME/.config}/swww/$curTheme"
         mapfile -d '' Wallist < <(find ${wallPath} -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) -print0 | sort -z)
         fullPath="${Wallist[0]}"
     else

--- a/Configs/.config/hypr/scripts/swwwallselect.sh
+++ b/Configs/.config/hypr/scripts/swwwallselect.sh
@@ -3,7 +3,7 @@
 # set variables
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-RofiConf="$HOME/.config/rofi/themeselect.rasi"
+RofiConf="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/themeselect.rasi"
 
 ctlLine=`grep '^1|' $ThemeCtl`
 if [ `echo $ctlLine | wc -l` -ne "1" ] ; then
@@ -13,8 +13,8 @@ fi
 
 fullPath=$(echo "$ctlLine" | awk -F '|' '{print $NF}' | sed "s+~+$HOME+")
 wallPath=$(dirname "$fullPath")
-if [ ! -d "${wallPath}" ] && [ -d "$HOME/.config/swww/${gtkTheme}" ] && [ ! -z "${gtkTheme}" ] ; then
-    wallPath="$HOME/.config/swww/${gtkTheme}"
+if [ ! -d "${wallPath}" ] && [ -d "${XDG_CONFIG_HOME:-$HOME/.config}/swww/${gtkTheme}" ] && [ ! -z "${gtkTheme}" ] ; then
+    wallPath="${XDG_CONFIG_HOME:-$HOME/.config}/swww/${gtkTheme}"
 fi
 
 

--- a/Configs/.config/hypr/scripts/testrunner.sh
+++ b/Configs/.config/hypr/scripts/testrunner.sh
@@ -2,8 +2,8 @@
 
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-WalDir="$HOME/.config/swww"
-RofDir="$HOME/.config/rofi"
+WalDir="${XDG_CONFIG_HOME:-$HOME/.config}/swww"
+RofDir="${XDG_CONFIG_HOME:-$HOME/.config}/rofi"
 
 roficn=0
 wlogcn=1

--- a/Configs/.config/hypr/scripts/themeselect.sh
+++ b/Configs/.config/hypr/scripts/themeselect.sh
@@ -3,7 +3,7 @@
 # set variables
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-RofiConf="$HOME/.config/rofi/themeselect.rasi"
+RofiConf="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/themeselect.rasi"
 
 
 # scale for monitor x res

--- a/Configs/.config/hypr/scripts/wallbashdunst.sh
+++ b/Configs/.config/hypr/scripts/wallbashdunst.sh
@@ -4,7 +4,7 @@
 
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-dstDir="$HOME/.config/dunst"
+dstDir="${XDG_CONFIG_HOME:-$HOME/.config}/dunst"
 
 # regen conf
 

--- a/Configs/.config/hypr/scripts/wallbashkvm.sh
+++ b/Configs/.config/hypr/scripts/wallbashkvm.sh
@@ -4,7 +4,7 @@
 
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-hypDir="$HOME/.config/hypr/themes"
+hypDir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/themes"
 
 # regen color conf
 

--- a/Configs/.config/hypr/scripts/wallbashrofi.sh
+++ b/Configs/.config/hypr/scripts/wallbashrofi.sh
@@ -4,7 +4,7 @@
 
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-rofThm="$HOME/.config/rofi/themes"
+rofThm="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/themes"
 
 # regen color conf
 

--- a/Configs/.config/hypr/scripts/wallbashspotify.sh
+++ b/Configs/.config/hypr/scripts/wallbashspotify.sh
@@ -4,8 +4,8 @@
 
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-scol="$HOME/.config/spicetify/Themes/Sleek/color.ini"
-dcol="$HOME/.config/spicetify/Themes/Sleek/Wall-Dcol.ini"
+scol="${XDG_CONFIG_HOME:-$HOME/.config}/spicetify/Themes/Sleek/color.ini"
+dcol="${XDG_CONFIG_HOME:-$HOME/.config}/spicetify/Themes/Sleek/Wall-Dcol.ini"
 
 # regen conf
 

--- a/Configs/.config/hypr/scripts/wallbashtoggle.sh
+++ b/Configs/.config/hypr/scripts/wallbashtoggle.sh
@@ -2,7 +2,7 @@
 
 # set variables
 ScrDir=`dirname $(realpath $0)`
-DcoDir="$HOME/.config/hypr/wallbash"
+DcoDir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/wallbash"
 TgtScr=$ScrDir/globalcontrol.sh
 source $ScrDir/globalcontrol.sh
 

--- a/Configs/.config/hypr/scripts/wallbashypr.sh
+++ b/Configs/.config/hypr/scripts/wallbashypr.sh
@@ -4,7 +4,7 @@
 
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-hypDir="$HOME/.config/hypr/themes"
+hypDir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/themes"
 
 # regen color conf
 

--- a/Configs/.config/hypr/scripts/wbarconfgen.sh
+++ b/Configs/.config/hypr/scripts/wbarconfgen.sh
@@ -4,7 +4,7 @@
 # read control file and initialize variables
 
 ScrDir=`dirname $(realpath $0)`
-waybar_dir="$HOME/.config/waybar"
+waybar_dir="${XDG_CONFIG_HOME:-$HOME/.config}/waybar"
 modules_dir="$waybar_dir/modules"
 conf_file="$waybar_dir/config.jsonc"
 conf_ctl="$waybar_dir/config.ctl"

--- a/Configs/.config/hypr/scripts/wbarstylegen.sh
+++ b/Configs/.config/hypr/scripts/wbarstylegen.sh
@@ -5,11 +5,11 @@
 
 ScrDir=`dirname $(realpath $0)`
 source $ScrDir/globalcontrol.sh
-waybar_dir="$HOME/.config/waybar"
+waybar_dir="${XDG_CONFIG_HOME:-$HOME/.config}/waybar"
 modules_dir="$waybar_dir/modules"
 in_file="$waybar_dir/modules/style.css"
 out_file="$waybar_dir/style.css"
-src_file="$HOME/.config/hypr/themes/theme.conf"
+src_file="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/themes/theme.conf"
 
 if [ "$EnableWallDcol" -eq 1 ] ; then
     ln -fs $waybar_dir/themes/Wall-Dcol.css $waybar_dir/themes/theme.css

--- a/Configs/.config/neofetch/config.conf
+++ b/Configs/.config/neofetch/config.conf
@@ -718,7 +718,7 @@ image_backend="kitty"
 # NOTE: 'auto' will pick the best image source for whatever image backend is used.
 #       In ascii mode, distro ascii art will be used and in an image mode, your
 #       wallpaper will be used.
-image_source=$(find $HOME/.config/neofetch/pngs/ -name "*.png" | sort -R | head -1)
+image_source=$(find "${XDG_CONFIG_HOME:-$HOME/.config}/neofetch/pngs/" -name "*.png" | sort -R | head -1)
 
 
 # Ascii Options

--- a/Scripts/.extra/restore_app.sh
+++ b/Scripts/.extra/restore_app.sh
@@ -28,11 +28,12 @@ sudo sed -i "/^Icon=/c\Icon=spectacle" /usr/share/applications/swappy.desktop
 # steam
 #if pkg_installed steam
 #    then
-#    if [ ! -d ~/.local/share/Steam/Skins/ ]
+#    skinsDir="${XDG_DATA_HOME:-$HOME/.local/share}/Steam/Skins/"
+#    if [ ! -d "$skinsDir" ]
 #        then
-#        mkdir -p ~/.local/share/Steam/Skins/
+#        mkdir -p "$skinsDir"
 #    fi
-#    tar -xzf ${CloneDir}/Source/arcs/Steam_Metro.tar.gz -C ~/.local/share/Steam/Skins/
+#    tar -xzf ${CloneDir}/Source/arcs/Steam_Metro.tar.gz -C "$skinsDir"
 #fi
 
 

--- a/Scripts/create_cache.sh
+++ b/Scripts/create_cache.sh
@@ -17,9 +17,9 @@ then
 fi
 
 # set variables
-ctlFile="$HOME/.config/hypr/theme.ctl"
+ctlFile="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/theme.ctl"
 ctlLine=`grep '^1|' $ctlFile`
-export cacheDir="$HOME/.config/swww/.cache"
+export cacheDir="${XDG_CONFIG_HOME:-$HOME/.config}/swww/.cache"
 
 # evaluate options
 while getopts "fc" option ; do

--- a/Scripts/themepatcher.sh
+++ b/Scripts/themepatcher.sh
@@ -20,7 +20,7 @@ if [[ -z $1 || -z $2 ]]; then ask_help ; exit 1 ; fi
 
 # set parameters
 Fav_Theme="$1"
-ThemeCtl="$HOME/.config/hypr/theme.ctl"
+ThemeCtl="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/theme.ctl"
 
 if [ -d "$2" ]; then
     Theme_Dir="$2"
@@ -93,10 +93,10 @@ fi
 # extract arcs
 prefix=("Gtk" "Font" "Icon" "Cursor")
 declare -A TrgtDir
-TrgtDir["Gtk"]="$HOME/.themes"                #mandatory
-TrgtDir["Font"]="$HOME/.local/share/fonts"    #optional
-TrgtDir["Icon"]="$HOME/.icons"                #optional
-TrgtDir["Cursor"]="$HOME/.icons"              #optional
+TrgtDir["Gtk"]="$HOME/.themes"                                  #mandatory
+TrgtDir["Font"]="${XDG_DATA_HOME:-$HOME/.local/share}/fonts"    #optional
+TrgtDir["Icon"]="$HOME/.icons"                                  #optional
+TrgtDir["Cursor"]="$HOME/.icons"                                #optional
 postfx=("tar.xz" "tar.gz")
 GtkFlag=0
 


### PR DESCRIPTION
Currently, the scripts will fail if a user chooses to customize the location of their config directory with `$XDG_CONFIG_HOME` or their data directory with `$XDG_DATA_HOME`. This isn't too uncommon and major desktop environments respect this choice as well.

This PR [implements the crutial parts of the XDG Base Directory Specification](https://xdgbasedirectoryspecification.com); the variables are first read, and only fall back to the values of `$HOME/.config` and `$HOME/.local/share`, respectively, if they are null or an empty string.

There are some other areas that have not been converted. Namely, the `.css` files (this can be searched with the search query `"$HOME"`) and the `restore_cfg.list`, since it is unclear whether the `${VAR:-fallback}` construct is supported. In any case, that part can be added later.