### PR TITLE
fix: Check `ZDOTDIR` when resolving location of ZSH rc file

### DIFF
--- a/Scripts/.old/zsh_plugin_installer.py
+++ b/Scripts/.old/zsh_plugin_installer.py
@@ -22,7 +22,7 @@ global RC_FILE
 ZSH_FOLDER = expanduser("/usr/share/oh-my-zsh")
 ZSH_CUSTOM_PLUGINS = join(ZSH_FOLDER, "custom/plugins")
 WORKARAOUND = False
-RC_FILE = expanduser(f"/home/{os.getlogin()}/.zshrc")
+RC_FILE = os.getenv('ZDOTDIR', default='') if os.getenv('ZDOTDIR', default='') != '' else expanduser(f"/home/{os.getlogin()}/.zshrc")
 # this is a workaround string to be able to load the completion plugin manually
 workaround = "fpath+=${ZSH_CUSTOM:-${ZSH:-/usr/share/oh-my-zsh}/custom}/plugins/zsh-completions/src"
 

--- a/Scripts/restore_zsh.sh
+++ b/Scripts/restore_zsh.sh
@@ -11,7 +11,7 @@ if [ $? -ne 0 ] ; then
 fi
 
 # set variables
-Zsh_rc="$HOME/.zshrc"
+Zsh_rc="${ZDOTDIR:-$HOME}/.zshrc"
 Zsh_Path="/usr/share/oh-my-zsh"
 Zsh_Plugins="$Zsh_Path/custom/plugins"
 Fix_Completion=""


### PR DESCRIPTION
Some scripts fail if `ZDOTDIR` is used to customize the location of `~/.zshrc`. This fixes that to take `ZDOTDIR` into consideration when resolving the ZSH rc file.