### PR TITLE
Quote pathname variables

### DIFF
--- a/Configs/.config/hypr/scripts/brightnesscontrol.sh
+++ b/Configs/.config/hypr/scripts/brightnesscontrol.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 
 function print_error

--- a/Configs/.config/hypr/scripts/cliphist.sh
+++ b/Configs/.config/hypr/scripts/cliphist.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 roconf="~/.config/rofi/clipboard.rasi"
 

--- a/Configs/.config/hypr/scripts/gamelauncher.sh
+++ b/Configs/.config/hypr/scripts/gamelauncher.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # set variables
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 ThemeSet="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/themes/theme.conf"
 RofiConf="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/steam/gamelauncher_${1}.rasi"

--- a/Configs/.config/hypr/scripts/globalcontrol.sh
+++ b/Configs/.config/hypr/scripts/globalcontrol.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # wallpaper var
-EnableWallDcol=0
+EnableWallDcol=1
 ConfDir="${XDG_CONFIG_HOME:-$HOME/.config}"
 CloneDir="$HOME/Hyprdots"
 ThemeCtl="$ConfDir/hypr/theme.ctl"

--- a/Configs/.config/hypr/scripts/keyboardswitch.sh
+++ b/Configs/.config/hypr/scripts/keyboardswitch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 
 hyprctl devices -j | jq -r '.keyboards[].name' | while read keyName

--- a/Configs/.config/hypr/scripts/logoutlaunch.sh
+++ b/Configs/.config/hypr/scripts/logoutlaunch.sh
@@ -8,7 +8,7 @@ then
 fi
 
 # set file variables
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 wLayout="${XDG_CONFIG_HOME:-$HOME/.config}/wlogout/layout_$1"
 wlTmplt="${XDG_CONFIG_HOME:-$HOME/.config}/wlogout/style_$1.css"

--- a/Configs/.config/hypr/scripts/quickapps.sh
+++ b/Configs/.config/hypr/scripts/quickapps.sh
@@ -2,7 +2,7 @@
 
 # set variables
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 roconf="~/.config/rofi/quickapps.rasi"
 

--- a/Configs/.config/hypr/scripts/rofilaunch.sh
+++ b/Configs/.config/hypr/scripts/rofilaunch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 roconf="~/.config/rofi/config.rasi"
 

--- a/Configs/.config/hypr/scripts/rofiselect.sh
+++ b/Configs/.config/hypr/scripts/rofiselect.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # set variables
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 RofiConf="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/themeselect.rasi"
 RofiStyle="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/styles"

--- a/Configs/.config/hypr/scripts/screenshot.sh
+++ b/Configs/.config/hypr/scripts/screenshot.sh
@@ -4,7 +4,7 @@ if [ -z "$XDG_PICTURES_DIR" ] ; then
     XDG_PICTURES_DIR="$HOME/Pictures"
 fi
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 swpy_dir="${XDG_CONFIG_HOME:-$HOME/.config}/swappy"
 save_dir="${2:-$XDG_PICTURES_DIR/Screenshots}"

--- a/Configs/.config/hypr/scripts/swwwallbash.sh
+++ b/Configs/.config/hypr/scripts/swwwallbash.sh
@@ -2,7 +2,7 @@
 
 # set variables
 
-export ScrDir=`dirname $(realpath $0)`
+export ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 dcoDir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/wallbash"
 input_wall="$1"

--- a/Configs/.config/hypr/scripts/swwwallpaper.sh
+++ b/Configs/.config/hypr/scripts/swwwallpaper.sh
@@ -26,7 +26,7 @@ Wall_Update()
     fi
 
     wait
-    awk -F '|' -v thm="${curTheme}" -v wal="${x_update}" '{OFS=FS} {if($2==thm)$NF=wal;print$0}' "${ThemeCtl}" > ${ScrDir}/tmp && mv ${ScrDir}/tmp "${ThemeCtl}"
+    awk -F '|' -v thm="${curTheme}" -v wal="${x_update}" '{OFS=FS} {if($2==thm)$NF=wal;print$0}' "${ThemeCtl}" > "${ScrDir}/tmp" && mv "${ScrDir}/tmp" "${ThemeCtl}"
     ln -fs "${x_wall}" "${wallSet}"
     ln -fs "${cacheDir}/${curTheme}/${cacheImg}.rofi" "${wallRfi}"
     ln -fs "${cacheDir}/${curTheme}/${cacheImg}.blur" "${wallBlr}"
@@ -70,7 +70,7 @@ Wall_Set()
 
 # set variables
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 wallSet="${XDG_CONFIG_HOME:-$HOME/.config}/swww/wall.set"
 wallBlr="${XDG_CONFIG_HOME:-$HOME/.config}/swww/wall.blur"

--- a/Configs/.config/hypr/scripts/swwwallselect.sh
+++ b/Configs/.config/hypr/scripts/swwwallselect.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env sh
 
 # set variables
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 RofiConf="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/themeselect.rasi"
 
-ctlLine=`grep '^1|' $ThemeCtl`
+ctlLine=`grep '^1|' "$ThemeCtl"`
 if [ `echo $ctlLine | wc -l` -ne "1" ] ; then
     echo "ERROR : $ThemeCtl Unable to fetch theme..."
     exit 1
@@ -39,7 +39,7 @@ done | rofi -dmenu -theme-str "${r_override}" -config "${RofiConf}" -select "${c
 
 # apply wallpaper
 if [ ! -z "${RofiSel}" ] ; then
-    ${ScrDir}/swwwallpaper.sh -s "${wallPath}/${RofiSel}"
+    "${ScrDir}/swwwallpaper.sh" -s "${wallPath}/${RofiSel}"
     dunstify "t1" -a " ${RofiSel}" -i "${cacheDir}/${gtkTheme}/${RofiSel}" -r 91190 -t 2200
 fi
 

--- a/Configs/.config/hypr/scripts/systemupdate.sh
+++ b/Configs/.config/hypr/scripts/systemupdate.sh
@@ -6,7 +6,7 @@ if [ ! -f /etc/arch-release ] ; then
 fi
 
 # source variables
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 
 # Check for updates

--- a/Configs/.config/hypr/scripts/testrunner.sh
+++ b/Configs/.config/hypr/scripts/testrunner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 WalDir="${XDG_CONFIG_HOME:-$HOME/.config}/swww"
 RofDir="${XDG_CONFIG_HOME:-$HOME/.config}/rofi"
@@ -87,5 +87,5 @@ do
             $ScrDir/volumecontrol.sh -o $vol
         done
     done
-done < $ThemeCtl
+done < "$ThemeCtl"
 

--- a/Configs/.config/hypr/scripts/themeselect.sh
+++ b/Configs/.config/hypr/scripts/themeselect.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # set variables
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 RofiConf="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/themeselect.rasi"
 
@@ -19,7 +19,7 @@ r_override="element{border-radius:${elem_border}px;} element-icon{border-radius:
 
 
 # launch rofi menu
-ThemeSel=$( cat $ThemeCtl | while read line
+ThemeSel=$( cat "$ThemeCtl" | while read line
 do
     thm=`echo $line | cut -d '|' -f 2`
     wal=`echo $line | awk -F '/' '{print $NF}'`
@@ -29,7 +29,7 @@ done | rofi -dmenu -theme-str "${r_override}" -config $RofiConf -select "${gtkTh
 
 # apply theme
 if [ ! -z $ThemeSel ] ; then
-    ${ScrDir}/themeswitch.sh -s $ThemeSel
+    "${ScrDir}/themeswitch.sh" -s $ThemeSel
     dunstify "t1" -a " ${ThemeSel}" -i "~/.config/dunst/icons/hyprdots.png" -r 91190 -t 2200
 fi
 

--- a/Configs/.config/hypr/scripts/themeswitch.sh
+++ b/Configs/.config/hypr/scripts/themeswitch.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 
 # set variables
-ScrDir=`dirname $(realpath $0)`
-source ${ScrDir}/globalcontrol.sh
+ScrDir=`dirname "$(realpath "$0")"`
+source "${ScrDir}/globalcontrol.sh"
 
 
 # evaluate options
@@ -10,7 +10,7 @@ while getopts "npst" option ; do
     case $option in
 
     n ) # set next theme
-        ThemeSet=`head -1 $ThemeCtl | cut -d '|' -f 2` #default value
+        ThemeSet=`head -1 "$ThemeCtl" | cut -d '|' -f 2` #default value
         flg=0
         while read line
         do
@@ -20,11 +20,11 @@ while getopts "npst" option ; do
             elif [ `echo $line | cut -d '|' -f 1` -eq 1 ] ; then
                 flg=1
             fi
-        done < $ThemeCtl
+        done < "$ThemeCtl"
         export xtrans="grow" ;;
 
     p ) # set previous theme
-        ThemeSet=`tail -1 $ThemeCtl | cut -d '|' -f 2` #default value
+        ThemeSet=`tail -1 "$ThemeCtl" | cut -d '|' -f 2` #default value
         flg=0
         while read line
         do
@@ -34,7 +34,7 @@ while getopts "npst" option ; do
             elif [ `echo $line | cut -d '|' -f 1` -eq 1 ] ; then
                 flg=1
             fi
-        done < <( tac $ThemeCtl )
+        done < <( tac "$ThemeCtl" )
         export xtrans="outer" ;;
 
     s ) # set selected theme
@@ -57,26 +57,26 @@ done
 
 
 # update theme control
-if [ `cat $ThemeCtl | awk -F '|' -v thm=$ThemeSet '{if($2==thm) print$2}' | wc -w` -ne 1 ] ; then
+if [ `cat "$ThemeCtl" | awk -F '|' -v thm=$ThemeSet '{if($2==thm) print$2}' | wc -w` -ne 1 ] ; then
     echo "Unknown theme selected: $ThemeSet"
     echo "Available themes are:"
-    cat $ThemeCtl | cut -d '|' -f 2
+    cat "$ThemeCtl" | cut -d '|' -f 2
     exit 1
 else
     echo "Selected theme: $ThemeSet"
-    sed -i "s/^1/0/g" $ThemeCtl
-    awk -F '|' -v thm=$ThemeSet '{OFS=FS} {if($2==thm) $1=1; print$0}' $ThemeCtl > ${ScrDir}/tmp && mv ${ScrDir}/tmp $ThemeCtl
+    sed -i "s/^1/0/g" "$ThemeCtl"
+    awk -F '|' -v thm=$ThemeSet '{OFS=FS} {if($2==thm) $1=1; print$0}' "$ThemeCtl" > "${ScrDir}/tmp" && mv "${ScrDir}/tmp" "$ThemeCtl"
 fi
 
 
 # swwwallpaper
-getWall=`grep '^1|' $ThemeCtl | awk -F '|' '{print $NF}'`
+getWall=`grep '^1|' "$ThemeCtl" | awk -F '|' '{print $NF}'`
 getWall=`eval echo "$getWall"`
 getName=`basename "$getWall"`
 ln -fs "$getWall" "$ConfDir/swww/wall.set"
 ln -fs "$cacheDir/${ThemeSet}/${getName}.rofi" "$ConfDir/swww/wall.rofi"
 ln -fs "$cacheDir/${ThemeSet}/${getName}.blur" "$ConfDir/swww/wall.blur"
-${ScrDir}/swwwallpaper.sh
+"${ScrDir}/swwwallpaper.sh"
 
 if [ $? -ne 0 ] ; then
     echo "ERROR: Unable to set wallpaper"
@@ -85,12 +85,12 @@ fi
 
 
 # code
-if [ ! -z "$(grep '^1|' $ThemeCtl | awk -F '|' '{print $3}')" ] ; then
-    codex=$(grep '^1|' $ThemeCtl | awk -F '|' '{print $3}' | cut -d '~' -f 1)
+if [ ! -z "$(grep '^1|' "$ThemeCtl" | awk -F '|' '{print $3}')" ] ; then
+    codex=$(grep '^1|' "$ThemeCtl" | awk -F '|' '{print $3}' | cut -d '~' -f 1)
     if [ $(code --list-extensions |  grep -iwc "${codex}") -eq 0 ] ; then
         code --install-extension "${codex}"
     fi
-    codet=$(grep '^1|' $ThemeCtl | awk -F '|' '{print $3}' | cut -d '~' -f 2)
+    codet=$(grep '^1|' "$ThemeCtl" | awk -F '|' '{print $3}' | cut -d '~' -f 2)
     jq --arg codet "${codet}" '.["workbench.colorTheme"] |= $codet' "$ConfDir/Code/User/settings.json" > tmpvsc && mv tmpvsc "$ConfDir/Code/User/settings.json"
 fi
 
@@ -126,5 +126,5 @@ hyprctl reload
 
 
 # wallbash
-${ScrDir}/swwwallbash.sh "$getWall"
+"${ScrDir}/swwwallbash.sh" "$getWall"
 

--- a/Configs/.config/hypr/scripts/volumecontrol.sh
+++ b/Configs/.config/hypr/scripts/volumecontrol.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 
 

--- a/Configs/.config/hypr/scripts/wallbashdunst.sh
+++ b/Configs/.config/hypr/scripts/wallbashdunst.sh
@@ -2,13 +2,13 @@
 
 # set variables
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 dstDir="${XDG_CONFIG_HOME:-$HOME/.config}/dunst"
 
 # regen conf
 
-cat $dstDir/dunst.conf $dstDir/Wall-Dcol.conf > $dstDir/dunstrc
+cat "$dstDir/dunst.conf" "$dstDir/Wall-Dcol.conf" > "$dstDir/dunstrc"
 killall dunst
 dunst &
 

--- a/Configs/.config/hypr/scripts/wallbashkvm.sh
+++ b/Configs/.config/hypr/scripts/wallbashkvm.sh
@@ -2,7 +2,7 @@
 
 # set variables
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 hypDir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/themes"
 

--- a/Configs/.config/hypr/scripts/wallbashrofi.sh
+++ b/Configs/.config/hypr/scripts/wallbashrofi.sh
@@ -2,7 +2,7 @@
 
 # set variables
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 rofThm="${XDG_CONFIG_HOME:-$HOME/.config}/rofi/themes"
 

--- a/Configs/.config/hypr/scripts/wallbashspotify.sh
+++ b/Configs/.config/hypr/scripts/wallbashspotify.sh
@@ -2,7 +2,7 @@
 
 # set variables
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 scol="${XDG_CONFIG_HOME:-$HOME/.config}/spicetify/Themes/Sleek/color.ini"
 dcol="${XDG_CONFIG_HOME:-$HOME/.config}/spicetify/Themes/Sleek/Wall-Dcol.ini"

--- a/Configs/.config/hypr/scripts/wallbashtoggle.sh
+++ b/Configs/.config/hypr/scripts/wallbashtoggle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # set variables
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 DcoDir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/wallbash"
 TgtScr=$ScrDir/globalcontrol.sh
 source $ScrDir/globalcontrol.sh

--- a/Configs/.config/hypr/scripts/wallbashypr.sh
+++ b/Configs/.config/hypr/scripts/wallbashypr.sh
@@ -2,7 +2,7 @@
 
 # set variables
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 hypDir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/themes"
 

--- a/Configs/.config/hypr/scripts/wbarconfgen.sh
+++ b/Configs/.config/hypr/scripts/wbarconfgen.sh
@@ -3,7 +3,7 @@
 
 # read control file and initialize variables
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 waybar_dir="${XDG_CONFIG_HOME:-$HOME/.config}/waybar"
 modules_dir="$waybar_dir/modules"
 conf_file="$waybar_dir/config.jsonc"

--- a/Configs/.config/hypr/scripts/wbarstylegen.sh
+++ b/Configs/.config/hypr/scripts/wbarstylegen.sh
@@ -3,7 +3,7 @@
 
 # detect hypr theme and initialize variables
 
-ScrDir=`dirname $(realpath $0)`
+ScrDir=`dirname "$(realpath "$0")"`
 source $ScrDir/globalcontrol.sh
 waybar_dir="${XDG_CONFIG_HOME:-$HOME/.config}/waybar"
 modules_dir="$waybar_dir/modules"

--- a/Scripts/.extra/install_fpk.sh
+++ b/Scripts/.extra/install_fpk.sh
@@ -4,12 +4,12 @@
 #|-/ /--| Prasanth Rangan                   |-/ /--|#
 #|/ /---+-----------------------------------+/ /---|#
 
-BaseDir=`dirname $(realpath $0)`
-ScrDir=`dirname $(dirname $(realpath $0))`
+BaseDir=`dirname "$(realpath "$0")"`
+ScrDir=`dirname "$(dirname "$(realpath "$0")")"`
 
 source $ScrDir/global_fn.sh
 if [ $? -ne 0 ] ; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 

--- a/Scripts/.extra/restore_app.sh
+++ b/Scripts/.extra/restore_app.sh
@@ -4,15 +4,15 @@
 #|-/ /--| Prasanth Rangan             |-/ /--|#
 #|/ /---+-----------------------------+/ /---|#
 
-ScrDir=`dirname $(dirname $(realpath $0))`
+ScrDir=`dirname "$(dirname "$(realpath "$0")")"`
 
 source $ScrDir/global_fn.sh
 if [ $? -ne 0 ] ; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 
-CloneDir=`dirname $(realpath $CloneDir)`
+CloneDir=`dirname "$(realpath $CloneDir)"`
 
 
 # icons

--- a/Scripts/.old/install_v1.sh
+++ b/Scripts/.old/install_v1.sh
@@ -9,7 +9,7 @@
 #--------------------------------#
 source global_fn.sh
 if [ $? -ne 0 ] ; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 

--- a/Scripts/.old/restore_chk.sh
+++ b/Scripts/.old/restore_chk.sh
@@ -6,7 +6,7 @@
 
 source global_fn.sh
 if [ $? -ne 0 ] ; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 

--- a/Scripts/create_cache.sh
+++ b/Scripts/create_cache.sh
@@ -6,7 +6,7 @@
 
 source global_fn.sh
 if [ $? -ne 0 ] ; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 

--- a/Scripts/global_fn.sh
+++ b/Scripts/global_fn.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-CloneDir=`dirname $(dirname $(realpath $0))`
+CloneDir=`dirname "$(dirname "$(realpath "$0")")"`
 
 service_ctl()
 {

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -23,7 +23,7 @@ EOF
 #--------------------------------#
 source global_fn.sh
 if [ $? -ne 0 ]; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 

--- a/Scripts/install_aur.sh
+++ b/Scripts/install_aur.sh
@@ -6,7 +6,7 @@
 
 source global_fn.sh
 if [ $? -ne 0 ] ; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 

--- a/Scripts/install_pkg.sh
+++ b/Scripts/install_pkg.sh
@@ -6,7 +6,7 @@
 
 source global_fn.sh
 if [ $? -ne 0 ] ; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 

--- a/Scripts/restore_cfg.sh
+++ b/Scripts/restore_cfg.sh
@@ -6,7 +6,7 @@
 
 source global_fn.sh
 if [ $? -ne 0 ] ; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 

--- a/Scripts/restore_etc.sh
+++ b/Scripts/restore_etc.sh
@@ -6,7 +6,7 @@
 
 source global_fn.sh
 if [ $? -ne 0 ] ; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 

--- a/Scripts/restore_fnt.sh
+++ b/Scripts/restore_fnt.sh
@@ -6,7 +6,7 @@
 
 source global_fn.sh
 if [ $? -ne 0 ] ; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 

--- a/Scripts/restore_lnk.sh
+++ b/Scripts/restore_lnk.sh
@@ -6,7 +6,7 @@
 
 source global_fn.sh
 if [ $? -ne 0 ] ; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 

--- a/Scripts/restore_zsh.sh
+++ b/Scripts/restore_zsh.sh
@@ -6,7 +6,7 @@
 
 source global_fn.sh
 if [ $? -ne 0 ] ; then
-    echo "Error: unable to source global_fn.sh, please execute from $(dirname $(realpath $0))..."
+    echo "Error: unable to source global_fn.sh, please execute from $(dirname "$(realpath "$0")")..."
     exit 1
 fi
 


### PR DESCRIPTION
Currently, if any of these scripts are in a directory path that contains whitespace, the script fails to work. This scenario is now possible, since #583 (`$XDG_CONFIG_HOME` can now resolve to somthing like `$HOME/.con fig`).

This fixes that, improving quoting hygeine.
