### PR TITLE
remove deprecated hyprland-nvidia-git

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -91,7 +91,6 @@ EOF
         done
 
         echo -e "nvidia-dkms\nnvidia-utils" >>install_pkg.lst
-        sed -i "s/^hyprland-git/hyprland-nvidia-git/g" install_pkg.lst
 
     else
         echo "nvidia card not detected, skipping nvidia drivers..."


### PR DESCRIPTION
#586 
hyprland-nvidia-git no longer needed.
https://github.com/hyprwm/Hyprland/pull/3957
we should use hyprland-git also in nvidia.