### PR TITLE
User Specific .zshrc

### DIFF
--- a/Configs/.zshrc
+++ b/Configs/.zshrc
@@ -62,3 +62,6 @@ alias vc='code' # gui code editor
 
 #Display Pokemon
 pokemon-colorscripts --no-title -r 1,3,6
+
+#Source ./zshrc-user #! May conflict with .zshrc file, Please be mindful.
+source $HOME/.zshrc-user

--- a/Scripts/restore_zsh.sh
+++ b/Scripts/restore_zsh.sh
@@ -33,3 +33,6 @@ done < <(cut -d '#' -f 1 restore_zsh.lst | sed 's/ //g')
 # update plugin array in zshrc
 echo "intalling zsh plugins --> ${w_plugin}"
 sed -i "/^plugins=/c\plugins=($w_plugin)$Fix_Completion" $Zsh_rc
+
+#? Check if the .zshrc file exists
+if [ ! -f $HOME/.zshrc-user ]; then touch $HOME/.zshrc-user ; fi

--- a/Scripts/restore_zsh.sh
+++ b/Scripts/restore_zsh.sh
@@ -34,5 +34,4 @@ done < <(cut -d '#' -f 1 restore_zsh.lst | sed 's/ //g')
 echo "intalling zsh plugins --> ${w_plugin}"
 sed -i "/^plugins=/c\plugins=($w_plugin)$Fix_Completion" $Zsh_rc
 
-#? Check if the .zshrc file exists
-if [ ! -f $HOME/.zshrc-user ]; then touch $HOME/.zshrc-user ; fi
+touch $HOME/.zshrc-user


### PR DESCRIPTION
Can we Have this I usually add custom $PATH also I have specifics for my ~/.zshrc . 

This change may solve regarding .zshrc was constantly overwritten upon restore. Also some may  have nix home manager specifics and custom $PATH    or what ever user specifics they need. 