### PR TITLE
FIX: Add Hyprland-Git 

### DIFF
--- a/Scripts/custom_hypr.lst
+++ b/Scripts/custom_hypr.lst
@@ -16,7 +16,7 @@ qt6-wayland
 qt5-quickcontrols
 qt5-quickcontrols2
 qt5-graphicaleffects
-hyprland
+hyprland-git
 dunst
 rofi-lbonn-wayland-git
 waybar


### PR DESCRIPTION
Adding Hyprland-Git back to the custom_hypr.lst as the official hyprland version is 5 releases behind the GIT, breaks changes in the themes. 

Fixes: #592 