### PR TITLE
Remove GDK_BACKEND Environment Variable

### DIFF
--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -50,7 +50,6 @@ exec-once = ~/.config/hypr/scripts/batterynotify.sh # battery notification
 env = XDG_CURRENT_DESKTOP,Hyprland
 env = XDG_SESSION_TYPE,wayland
 env = XDG_SESSION_DESKTOP,Hyprland
-env = GDK_BACKEND,wayland
 env = QT_QPA_PLATFORM,wayland
 #env = QT_STYLE_OVERRIDE,kvantum
 env = QT_QPA_PLATFORMTHEME,qt5ct


### PR DESCRIPTION
It seems that certain apps (not all though weirdly) for some reason crash when trying to open a file chooser/saver, and it seems to be because of the GDK_BACKEND environment variable because it completely fixes the issue when removed. I can't think of a reason why the environment variable needs to exist, if it has a reason that's okay we can keep it, but if not can we remove it?