### PR TITLE
Add support for gtk4 specific applications

### DIFF
--- a/Configs/.config/hypr/scripts/themeswitch.sh
+++ b/Configs/.config/hypr/scripts/themeswitch.sh
@@ -115,6 +115,11 @@ sed -i "/^gtk-theme-name=/c\gtk-theme-name=${ThemeSet}" $ConfDir/gtk-3.0/setting
 sed -i "/^gtk-icon-theme-name=/c\gtk-icon-theme-name=${IconSet}" $ConfDir/gtk-3.0/settings.ini
 
 
+# gtk4
+rm ~/.config/gtk-4.0
+ln -s /usr/share/themes/${ThemeSet}/gtk-4.0 ~/.config/gtk-4.0
+
+
 # flatpak GTK
 flatpak --user override --env=GTK_THEME="${ThemeSet}"
 flatpak --user override --env=ICON_THEME="${IconSet}"

--- a/Configs/.config/hypr/scripts/themeswitch.sh
+++ b/Configs/.config/hypr/scripts/themeswitch.sh
@@ -116,8 +116,8 @@ sed -i "/^gtk-icon-theme-name=/c\gtk-icon-theme-name=${IconSet}" $ConfDir/gtk-3.
 
 
 # gtk4
-rm ~/.config/gtk-4.0
-ln -s /usr/share/themes/${ThemeSet}/gtk-4.0 ~/.config/gtk-4.0
+rm $ConfDir/gtk-4.0
+ln -s /usr/share/themes/$ThemeSet/gtk-4.0 $ConfDir/gtk-4.0
 
 
 # flatpak GTK


### PR DESCRIPTION
This will add support for applications that rely only on gtk4 by symlinking the installed gtk theme directory to `~/.config/gtk-4.0`. Works as intended when I tested it.