### PR TITLE
BkpDir: 231209_13h02m30s

### DIFF
--- a/Scripts/restore_cfg.sh
+++ b/Scripts/restore_cfg.sh
@@ -18,7 +18,7 @@ if [ ! -f "${ThemeOverride}restore_cfg.lst" ] || [ ! -d "${CfgDir}" ] ; then
     exit 1
 fi
 
-BkpDir="${HOME}/.config/cfg_backups/$(date +'%Y_%b_%d_%a_%Hh%Mm%Ss.bak')"
+BkpDir="${HOME}/.config/cfg_backups/$(date +'%y%m%d_%Hh%Mm%Ss')"
 
 if [ -d $BkpDir ] ; then
     echo "ERROR : $BkpDir exists!"

--- a/Scripts/restore_cfg.sh
+++ b/Scripts/restore_cfg.sh
@@ -18,7 +18,7 @@ if [ ! -f "${ThemeOverride}restore_cfg.lst" ] || [ ! -d "${CfgDir}" ] ; then
     exit 1
 fi
 
-BkpDir="${HOME}/.config/cfg_backups/$(date +'cfg_%y%m%d_%Hh%Mm%Ss')"
+BkpDir="${HOME}/.config/cfg_backups/$(date +'%Y_%b_%d_%a_%Hh%Mm%Ss.bak')"
 
 if [ -d $BkpDir ] ; then
     echo "ERROR : $BkpDir exists!"


### PR DESCRIPTION
Since ./cfg_backups gives the distinction already can we have this, please? This makes it faster to read and also easy to script. Thanks! 

``` 
❯ date +'%Y_%b_%d_%a_%Hh%Mm%Ss.bak'
2023_Dec_08_Fri_23h00m01s.bak
```