### PR TITLE
Partial revert to commit in globalcontrol.sh

### DIFF
--- a/Configs/.config/hypr/scripts/globalcontrol.sh
+++ b/Configs/.config/hypr/scripts/globalcontrol.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # wallpaper var
-EnableWallDcol=1
+EnableWallDcol=0
 ConfDir="${XDG_CONFIG_HOME:-$HOME/.config}"
 CloneDir="$HOME/Hyprdots"
 ThemeCtl="$ConfDir/hypr/theme.ctl"


### PR DESCRIPTION
https://github.com/prasanthrangan/hyprdots/commit/732d7dc5d538a8bb045da6d36a0aced3113be76d changed a line that changed the way waybar (and possibly other configs) got there colors. For a while i noticed that waybar looked weird, like text was displaying red. Found that it was using my wallpaper for colors rather than the current gtk theme, looked and found the commit that changed that, i don't know if it was intentional but i think by default it should use the current gtk theme.

So tl;dr, this doesn't necessarily fix anything but just changes using wallpaper colors for the theme back to using the current gtk theme.