### PR TITLE
fix: install script not waiting for user input

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -72,7 +72,7 @@ if [ $flg_Install -eq 1 ] && [ $flg_Restore -eq 1 ]; then
 
 EOF
 
-    ./install_pre.sh
+    source ./install_pre.sh
 fi
 
 


### PR DESCRIPTION
# Pull Request

## Description

Fixed `install.sh` not waiting for the user input of `Apply grub theme? [Y/N]`

As the script install_pre.sh has been called directly from install.sh, it silently skips the user input asking "Apply grub theme? [Y/N] : " and proceeds to install grub theme as the parent's stdin is not available to the child shell. This commit fixes the issue by calling install_pre.sh from install.sh using the source command.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
