### PR TITLE
[Feature]Display Bluetooth Battery

### DIFF
--- a/Configs/.config/waybar/modules/bluetooth.jsonc
+++ b/Configs/.config/waybar/modules/bluetooth.jsonc
@@ -2,7 +2,8 @@
     "format": "",
     "format-disabled": "",
     "format-connected": " {num_connections}",
-    "format-connected-battery": "{icon} {device_alias}-{device_battery_percentage}%",
+    "format-connected-battery": "{icon} {num_connections}",
+    // "format-connected-battery": "{icon} {device_alias}-{device_battery_percentage}%",
     "format-icons": ["󰥇", "󰤾", "󰤿", "󰥀", "󰥁", "󰥂", "󰥃", "󰥄", "󰥅", "󰥆", "󰥈"],
     // "format-device-preference": [ "device1", "device2" ], // preference list deciding the displayed device If this config option is not defined or none of the devices in the list are connected, it will fall back to showing the last connected device.
     "tooltip-format": "{controller_alias}\n{num_connections} connected",

--- a/Configs/.config/waybar/modules/bluetooth.jsonc
+++ b/Configs/.config/waybar/modules/bluetooth.jsonc
@@ -1,9 +1,12 @@
-    "bluetooth": {
-        "format": "",
-        "format-disabled": "", // an empty format will hide the module
-        "format-connected": " {num_connections}",
-        "tooltip-format": " {device_alias}",
-        "tooltip-format-connected": "{device_enumerate}",
-        "tooltip-format-enumerate-connected": " {device_alias}"
+"bluetooth": {
+    "format": "",
+    "format-disabled": "",
+    "format-connected": " {num_connections}",
+    "format-connected-battery": "{icon} {device_alias}-{device_battery_percentage}%",
+    "format-icons": ["󰥇", "󰤾", "󰤿", "󰥀", "󰥁", "󰥂", "󰥃", "󰥄", "󰥅", "󰥆", "󰥈"],
+    // "format-device-preference": [ "device1", "device2" ], // preference list deciding the displayed device If this config option is not defined or none of the devices in the list are connected, it will fall back to showing the last connected device.
+    "tooltip-format": "{controller_alias}\n{num_connections} connected",
+    "tooltip-format-connected": "{controller_alias}\n{num_connections} connected\n\n{device_enumerate}",
+    "tooltip-format-enumerate-connected": "{device_alias}",
+    "tooltip-format-enumerate-connected-battery": "{device_alias}\t{icon} {device_battery_percentage}%"
     },
-


### PR DESCRIPTION
# Pull Request

## Description

Discussion here
#757 
Added battery percentage for Bluetooth devices with battery.  
See the file and uncomment this part if the user prefers a certain device 
```
     "format-device-preference": [ "device1", "device2" ], // preference list deciding the displayed device If this config option is not defined or none of the devices in the list are connected, it will fall back to showing the last connected device.
```

#### Waybar says: 
format-device-preference:
typeof: array
A ranking of bluetooth devices, addressed by their alias. The order is from first displayed to last displayed.
If this config option is not defined or none of the devices in the list are connected, it will fall back to showing the last connected device.


## Type of change

Please put an `x` in the boxes that apply:

- [x] **New feature** (non-breaking change which adds functionality)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

![image](https://github.com/prasanthrangan/hyprdots/assets/53417443/e91a7703-614e-4812-9397-3e7af9c06820)
![image](https://github.com/prasanthrangan/hyprdots/assets/53417443/5753d003-0755-42cf-9fae-c3cb9f8fa6d2)
![image](https://github.com/prasanthrangan/hyprdots/assets/53417443/e5be882d-1a05-4394-86e1-ed0e1176ba5c)


## Additional context

Add any other context about the problem here.
