### PR TITLE
Spotify theme change

### DIFF
--- a/Configs/.config/hypr/scripts/themeselect.sh
+++ b/Configs/.config/hypr/scripts/themeselect.sh
@@ -32,4 +32,12 @@ if [ ! -z $ThemeSel ] ; then
     "${ScrDir}/themeswitch.sh" -s $ThemeSel
     dunstify "t1" -a " ${ThemeSel}" -i "~/.config/dunst/icons/hyprdots.png" -r 91190 -t 2200
 fi
+# Changing Spotify Theme
+if pgrep -x "spotify" > /dev/null; then
+    # Spotify is running, so update spicetify without opening Spotify
+    spicetify apply
+else
+    # Spotify is not running, update spicetify and do not open Spotify
+    spicetify update --noinput
+fi
 

--- a/Configs/.config/hypr/scripts/themeselect.sh
+++ b/Configs/.config/hypr/scripts/themeselect.sh
@@ -38,6 +38,8 @@ if pgrep -x "spotify" > /dev/null; then
     spicetify apply
 else
     # Spotify is not running, update spicetify and do not open Spotify
-    spicetify update --noinput
+    spicetify apply
+    killall spotify
 fi
+
 


### PR DESCRIPTION
# Pull Request

## Description

- An issue where the the Spotify theme did'nt change whenever the user switched the theme
- "spicetify-cli" is needed for this. With appropriate permissions is needed. Read [this](https://spicetify.app/docs/advanced-usage/installation#aur)
- ISSUE  :- https://github.com/prasanthrangan/hyprdots/issues/786

## Type of change


- [x] **New feature** (Spoitfy now changes theme whenever a theme is switched)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

