### PR TITLE
Waybar Network Module Styles 

### DIFF
--- a/Configs/.config/waybar/config.jsonc
+++ b/Configs/.config/waybar/config.jsonc
@@ -158,14 +158,15 @@
     },
 
     "network": {
-        // "interface": "wlp2*", // (Optional) To force the use of this interface
-        "format-wifi": "󰤨 {essid}",
-        "format-ethernet": "󱘖 Wired",
-        "tooltip-format": "󱘖 {ipaddr}  {bandwidthUpBytes}  {bandwidthDownBytes}",
-        "format-linked": "󱘖 {ifname} (No IP)",
-        "format-disconnected": " Disconnected",
-        "format-alt": "󰤨 {signalStrength}%",
-        "interval": 5
+        "tooltip": true,
+        "format-wifi": " ",
+        "format-ethernet": "󰈀 ",
+        "tooltip-format": "Network: <big><b>{essid}</b></big>\nSignal strength: <b>{signaldBm}dBm ({signalStrength}%)</b>\nFrequency: <b>{frequency}MHz</b>\nInterface: <b>{ifname}</b>\nIP: <b>{ipaddr}/{cidr}</b>\nGateway: <b>{gwaddr}</b>\nNetmask: <b>{netmask}</b>",
+        "format-linked": "󰈀 {ifname} (No IP)",
+        "format-disconnected": "󰖪 ",
+        "tooltip-format-disconnected": "Disconnected",
+        "format-alt": "<span foreground='#99ffdd'> {bandwidthDownBytes}</span> <span foreground='#ffcc66'> {bandwidthUpBytes}</span>",
+        "interval": 2,
     },
 
     "bluetooth": {

--- a/Configs/.config/waybar/modules/network.jsonc
+++ b/Configs/.config/waybar/modules/network.jsonc
@@ -1,11 +1,11 @@
     "network": {
-        // "interface": "wlp2*", // (Optional) To force the use of this interface
-        "format-wifi": "󰤨 {essid}",
-        "format-ethernet": "󱘖 Wired",
-        "tooltip-format": "󱘖 {ipaddr}  {bandwidthUpBytes}  {bandwidthDownBytes}",
-        "format-linked": "󱘖 {ifname} (No IP)",
-        "format-disconnected": " Disconnected",
-        "format-alt": "󰤨 {signalStrength}%",
-        "interval": 5
+        "tooltip": true,
+        "format-wifi": " ",
+        "format-ethernet": "󰈀 ",
+        "tooltip-format": "Network: <big><b>{essid}</b></big>\nSignal strength: <b>{signaldBm}dBm ({signalStrength}%)</b>\nFrequency: <b>{frequency}MHz</b>\nInterface: <b>{ifname}</b>\nIP: <b>{ipaddr}/{cidr}</b>\nGateway: <b>{gwaddr}</b>\nNetmask: <b>{netmask}</b>",
+        "format-linked": "󰈀 {ifname} (No IP)",
+        "format-disconnected": "󰖪 ",
+        "tooltip-format-disconnected": "Disconnected",
+        "format-alt": "<span foreground='#99ffdd'> {bandwidthDownBytes}</span> <span foreground='#ffcc66'> {bandwidthUpBytes}</span>",
+        "interval": 2,
     },
-


### PR DESCRIPTION
# Pull Request

## Description

New waybar network module style.
Now by default only icon (for economy space).
Tooltip with full network information.
Alt view with upload and download speed.
NerdFontIcons

## Screenshots

![240123_08h45m30s_screenshot](https://github.com/prasanthrangan/hyprdots/assets/70325462/3a523aa1-3bd9-4207-912c-2ad614552c32)
![240123_08h46m22s_screenshot](https://github.com/prasanthrangan/hyprdots/assets/70325462/628a180c-f78c-4eb7-8303-7c86b47559c6)
![240123_08h47m00s_screenshot](https://github.com/prasanthrangan/hyprdots/assets/70325462/b411de1f-d208-4faf-a4bd-cbcc8596e7c2)
