### PR TITLE
[Disable] Hyprland waifu,wallpaper.splash

### DIFF
--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -117,6 +117,9 @@ master {
 
 misc {
     vrr = 0
+    disable_hyprland_logo = true
+    disable_splash_rendering = true
+    force_default_wallpaper = 0
 }
 
 


### PR DESCRIPTION
# Pull Request

## Description

Please read these instructions and remove unnecessary text.

Disable Anime Waifu as some users are embarrassed in the office. 😅

Real reason is it looks unnatural upon startup as the waifu is displayed few ms before swww shows up


## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [*] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [ x I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.

