### PR TITLE
[FIX] restore_shl.sh

### DIFF
--- a/Scripts/restore_shl.sh
+++ b/Scripts/restore_shl.sh
@@ -44,7 +44,7 @@ if pkg_installed zsh && pkg_installed oh-my-zsh-git ; then
         if [ "$z_plugin" == "zsh-completions" ] && [ `grep 'fpath+=.*plugins/zsh-completions/src' $Zsh_rc | wc -l` -eq 0 ]; then
             Fix_Completion='\nfpath+=${ZSH_CUSTOM:-${ZSH:-/usr/share/oh-my-zsh}/custom}/plugins/zsh-completions/src'
         else
-            w_plugin=`echo $w_plugin ${z_plugin}`
+            w_plugin=$(echo ${w_plugin} ${z_plugin})
         fi
     done < <(cut -d '#' -f 1 restore_zsh.lst | sed 's/ //g')
 
@@ -54,9 +54,9 @@ if pkg_installed zsh && pkg_installed oh-my-zsh-git ; then
 fi
 
 # set shell
-if [ $(grep $USER /etc/passwd | awk -F '/' '{print $NF}') != "${myShell}" ] ; then
+if [[ "$(grep "${USER:}" /etc/passwd | awk -F '/' '{print $NF}')" != "${myShell}" ]] ; then
     echo -e "\033[0;32m[SHELL]\033[0m changing shell to ${myShell}..."
-    chsh -s $(which ${myShell})
+    chsh -s "$(which ${myShell})"
 else
     echo -e "\033[0;33m[SKIP]\033[0m ${myShell} is already configured..."
 fi

--- a/Scripts/restore_shl.sh
+++ b/Scripts/restore_shl.sh
@@ -54,7 +54,7 @@ if pkg_installed zsh && pkg_installed oh-my-zsh-git ; then
 fi
 
 # set shell
-if [[ "$(grep "${USER:}" /etc/passwd | awk -F '/' '{print $NF}')" != "${myShell}" ]] ; then
+if [[ "$(grep "/${USER}:" /etc/passwd | awk -F '/' '{print $NF}')" != "${myShell}" ]] ; then
     echo -e "\033[0;32m[SHELL]\033[0m changing shell to ${myShell}..."
     chsh -s "$(which ${myShell})"
 else


### PR DESCRIPTION
# Pull Request

## Description

Please read these instructions and remove unnecessary text.

Fixes this error : 

```
❯ ./restore_shl.sh
[SHELL] detected // zsh
intalling zsh plugins (git sudo zsh-256color zsh-autosuggestions zsh-syntax-highlighting)
./restore_shl.sh: line 57: [: too many arguments
[SKIP] zsh is already configured...

```
Also ensures $USER only matches the exact user 
```
if [[ "$(grep "/${USER}:" /etc/passwd | awk -F '/' '{print $NF}')" != "${myShell}" ]] ; then
```
Added / and : around $USER to match exactly. If system has multiple users e.g "khing" "khing-test"

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)


## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

![image](https://github.com/prasanthrangan/hyprdots/assets/53417443/d876ba5a-7965-4588-a87b-affc7391dee1)


## Additional context

Add any other context about the problem here.
