### PR TITLE
[Ready]  Support .gif files

### DIFF
--- a/Configs/.config/hypr/scripts/swwwallbash.sh
+++ b/Configs/.config/hypr/scripts/swwwallbash.sh
@@ -38,7 +38,7 @@ dark_light () {
 
 if [ ! -f "${cacheDir}/${gtkTheme}/${cacheImg}.dcol" ] ; then
     mkdir -p "${cacheDir}/${gtkTheme}"
-    dcol=(`magick "${input_wall}" -colors 3 -define histogram:unique-colors=true -format "%c" histogram:info: | awk '{print substr($3,2,6)}' | awk '{printf "%d %s\n", "0x"$1, $0}' | sort -n | awk '{print $2}'`)
+    dcol=(`magick "${input_wall}"[0] -colors 3 -define histogram:unique-colors=true -format "%c" histogram:info: | awk '{print substr($3,2,6)}' | awk '{printf "%d %s\n", "0x"$1, $0}' | sort -n | awk '{print $2}'`)
     for (( i = 1; i < 3; i++ )) ; do
         [ -z "${dcol[i]}" ] && dcol[i]=${dcol[i-1]}
     done

--- a/Configs/.config/hypr/scripts/swwwallpaper.sh
+++ b/Configs/.config/hypr/scripts/swwwallpaper.sh
@@ -58,13 +58,15 @@ Wall_Set()
         xtrans="grow"
     fi
 
-    swww img "$wallSet" \
+#? getting the real path as symlinks too glitch
+    swww img "$(readlink "${wallSet}")" \
     --transition-bezier .43,1.19,1,.4 \
     --transition-type "$xtrans" \
     --transition-duration 0.7 \
     --transition-fps 60 \
     --invert-y \
-    --transition-pos "$( hyprctl cursorpos )"
+    --transition-pos "$( hyprctl cursorpos )"    
+
 }
 
 
@@ -126,10 +128,10 @@ done
 
 # check swww daemon and set wall
 
+
 swww query
 if [ $? -eq 1 ] ; then
     swww init
 fi
 
 Wall_Set
-

--- a/Configs/.config/hypr/scripts/swwwallpaper.sh
+++ b/Configs/.config/hypr/scripts/swwwallpaper.sh
@@ -14,15 +14,15 @@ Wall_Update()
     $ScrDir/swwwallbash.sh "$x_wall" &
 
     if [ ! -f "${cacheDir}/${curTheme}/${cacheImg}" ] ; then
-        convert -strip "$x_wall" -thumbnail 500x500^ -gravity center -extent 500x500 "${cacheDir}/${curTheme}/${cacheImg}" &
+        convert -strip "${x_wall}"[0] -thumbnail 500x500^ -gravity center -extent 500x500 "${cacheDir}/${curTheme}/${cacheImg}" &
     fi
 
     if [ ! -f "${cacheDir}/${curTheme}/${cacheImg}.rofi" ] ; then
-        convert -strip -resize 2000 -gravity center -extent 2000 -quality 90 "$x_wall" "${cacheDir}/${curTheme}/${cacheImg}.rofi" &
+        convert -strip -resize 2000 -gravity center -extent 2000 -quality 90 "$x_wall"[0] "${cacheDir}/${curTheme}/${cacheImg}.rofi" &
     fi
 
     if [ ! -f "${cacheDir}/${curTheme}/${cacheImg}.blur" ] ; then
-        convert -strip -scale 10% -blur 0x3 -resize 100% "$x_wall" "${cacheDir}/${curTheme}/${cacheImg}.blur" &
+        convert -strip -scale 10% -blur 0x3 -resize 100% "$x_wall"[0] "${cacheDir}/${curTheme}/${cacheImg}.blur" &
     fi
 
     wait
@@ -86,12 +86,12 @@ curTheme=$(echo "$ctlLine" | awk -F '|' '{print $2}')
 fullPath=$(echo "$ctlLine" | awk -F '|' '{print $NF}' | sed "s+~+$HOME+")
 wallName=$(basename "$fullPath")
 wallPath=$(dirname "$fullPath")
-mapfile -d '' Wallist < <(find ${wallPath} -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) -print0 | sort -z)
+mapfile -d '' Wallist < <(find ${wallPath} -type f \( -iname "*.gif" -o -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) -print0 | sort -z)
 
 if [ ! -f "$fullPath" ] ; then
     if [ -d "${XDG_CONFIG_HOME:-$HOME/.config}/swww/$curTheme" ] ; then
         wallPath="${XDG_CONFIG_HOME:-$HOME/.config}/swww/$curTheme"
-        mapfile -d '' Wallist < <(find ${wallPath} -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) -print0 | sort -z)
+        mapfile -d '' Wallist < <(find ${wallPath} -type f \( -iname "*.gif" -o -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) -print0 | sort -z)
         fullPath="${Wallist[0]}"
     else
         echo "ERROR: wallpaper $fullPath not found..."

--- a/Configs/.config/hypr/scripts/swwwallselect.sh
+++ b/Configs/.config/hypr/scripts/swwwallselect.sh
@@ -31,7 +31,7 @@ r_override="element{border-radius:${elem_border}px;} listview{columns:6;spacing:
 
 # launch rofi menu
 currentWall=`basename $fullPath`
-RofiSel=$( find "${wallPath}" -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) -exec basename {} \; | sort | while read rfile
+RofiSel=$( find "${wallPath}" -type f \( -iname "*.gif" -o -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) -exec basename {} \; | sort | while read rfile
 do
     echo -en "$rfile\x00icon\x1f${cacheDir}/${gtkTheme}/${rfile}\n"
 done | rofi -dmenu -theme-str "${r_override}" -config "${RofiConf}" -select "${currentWall}")

--- a/Scripts/create_cache.sh
+++ b/Scripts/create_cache.sh
@@ -78,19 +78,19 @@ imagick_t2 () {
     wpBaseName=$(basename "${wpFullName}")
 
     if [ ! -f "${cacheDir}/${theme}/${wpBaseName}" ]; then
-        convert "${wpFullName}" -thumbnail 500x500^ -gravity center -extent 500x500 "${cacheDir}/${theme}/${wpBaseName}"
+        convert "${wpFullName}"[0] -thumbnail 500x500^ -gravity center -extent 500x500 "${cacheDir}/${theme}/${wpBaseName}"
     fi
 
     if [ ! -f "${cacheDir}/${theme}/${wpBaseName}.rofi" ]; then
-        convert -strip -resize 2000 -gravity center -extent 2000 -quality 90 "${wpFullName}" "${cacheDir}/${theme}/${wpBaseName}.rofi"
+        convert -strip -resize 2000 -gravity center -extent 2000 -quality 90 "${wpFullName}"[0] "${cacheDir}/${theme}/${wpBaseName}.rofi"
     fi
 
     if [ ! -f "${cacheDir}/${theme}/${wpBaseName}.blur" ]; then
-        convert -strip -scale 10% -blur 0x3 -resize 100% "${wpFullName}" "${cacheDir}/${theme}/${wpBaseName}.blur"
+        convert -strip -scale 10% -blur 0x3 -resize 100% "${wpFullName}"[0] "${cacheDir}/${theme}/${wpBaseName}.blur"
     fi
 
     if [ ! -f "${cacheDir}/${theme}/${wpBaseName}.dcol" ] ; then
-        dcol=(`magick "${wpFullName}" -colors 3 -define histogram:unique-colors=true -format "%c" histogram:info: | awk '{print substr($3,2,6)}' | awk '{printf "%d %s\n", "0x"$1, $0}' | sort -n | awk '{print $2}'`)
+        dcol=(`magick "${wpFullName}"[0] -colors 3 -define histogram:unique-colors=true -format "%c" histogram:info: | awk '{print substr($3,2,6)}' | awk '{printf "%d %s\n", "0x"$1, $0}' | sort -n | awk '{print $2}'`)
         for (( i = 1; i < 3; i++ )) ; do
             [ -z "${dcol[i]}" ] && dcol[i]=${dcol[i-1]}
         done
@@ -118,6 +118,9 @@ imagick_t2 () {
     fi
 }
 
+
+
+
 export -f hex_conv
 export -f dark_light
 export -f imagick_t2
@@ -129,9 +132,10 @@ do
     fullPath=$(echo "$ctlLine" | awk -F '|' '{print $NF}' | sed "s+~+$HOME+")
     wallPath=$(dirname "$fullPath")
     mkdir -p ${cacheDir}/${theme}
-    mapfile -d '' wpArray < <(find "${wallPath}" -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) -print0 | sort -z)
+    mapfile -d '' wpArray < <(find "${wallPath}" -type f \( -iname "*.gif" -o -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) -print0 | sort -z)
     echo "Creating thumbnails for ${theme} [${#wpArray[@]}]"
     parallel --bar imagick_t2 ::: "${theme}" ::: "${wpArray[@]}"
+
     if [ ! -z "$(echo $ctlLine | awk -F '|' '{print $3}')" ] ; then
         codex=$(echo $ctlLine | awk -F '|' '{print $3}' | cut -d '~' -f 1)
         if [ $(code --list-extensions |  grep -iwc "${codex}") -eq 0 ] ; then
@@ -139,4 +143,5 @@ do
         fi
     fi
 done < $ctlFile
+
 


### PR DESCRIPTION
# Pull Request

## Description

~This is buggy/. Transitions on swww glitches the GIF. Can be fixed with
``` swww kill && swww init ``` but that would remove capability to have fancy transitions
 For now we can check is file is .gif then  gives flags or something to kill and initialize swww again or
 do not give transitions for .gif images(kill and init is faster than this ).~
 
> There should be a better solutions so I need some eyes here :

Solution: Instead of setting a symlink for the wallpaper use the real path 

* Sorry for always having an MR entry, it might be annoying. 

## Type of change

Please put an `x` in the boxes that apply:

- [x] **New feature** (non-breaking change which adds functionality)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] My change requires a change to the documentation.
- [x] I have tested my code locally and it works as expected.


## Preview:
https://github.com/prasanthrangan/hyprdots/assets/53417443/f65fa17f-b12e-49ac-9611-e0e702765ff6

## CPU usage: 

https://github.com/prasanthrangan/hyprdots/assets/53417443/ea46cf9e-35f5-4b61-a74a-6122d7da7264

## Additional context

 Instead of setting a symlink for the wallpaper use the real path 
