### PR TITLE
Reduces Dunst Timeout from 10s to 4s

### DIFF
--- a/Configs/.config/dunst/dunstrc
+++ b/Configs/.config/dunst/dunstrc
@@ -455,11 +455,11 @@
     foreground = "#E2DFD1"
     frame_color = "#262C48"
     icon = "~/.config/dunst/icons/hyprdots.svg"
-    timeout = 10
+    timeout = 4
 
 [urgency_normal]
     background = "#4D5C78"
     foreground = "#E2DFD1"
     frame_color = "#622D28"
     icon = "~/.config/dunst/icons/hyprdots.svg"
-    timeout = 10
+    timeout = 4


### PR DESCRIPTION
# Pull Request
Reduces Dunst Timeout from 10s to 4s
## Description
Changes Dunst (Notification Server) timeout for normal and low urgency events from 10 to 4. This reduces notification stacking and clutter.

Note: While using programs that produce a lot of notifications such as a busy email client or Spotify, notifications of extended duration cause usability issues.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [x] **Other** (provide details below)

Configuration Change

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.
