### PR TITLE
[Enhance] Clarity for Kitty Dcol

### DIFF
--- a/Configs/.config/hypr/wallbash/kitty.dcol
+++ b/Configs/.config/hypr/wallbash/kitty.dcol
@@ -1,6 +1,5 @@
 $HOME/.config/kitty/themes/Wall-Dcol.conf|${ScrDir}/wallbashkitty.sh
 foreground         #<wallbash_pry2>
-#background        #<wallbash_pry0>  # This looks way better but not good for low contrast, high brightness walls
 background         #<wallbash_0xa1>
 cursor             #<wallbash_txt1> 
 
@@ -13,19 +12,24 @@ active_border_color   #<wallbash_pry1>
 inactive_border_color #<wallbash_pry2>
 bell_border_color     #<wallbash_1xa4>
 
-color0       #<wallbash_pry0>
-color8       #<wallbash_1xa2>
-color1       #<wallbash_txt1>
-color9       #<wallbash_pry1>
-color2       #<wallbash_2xa4>
-color10      #<wallbash_2xa4>
-color3       #<wallbash_1xa3>
-color11      #<wallbash_1xa3>
-color4       #<wallbash_2xa1>
-color12      #<wallbash_2xa1>
-color5       #<wallbash_2xa2>
-color13      #<wallbash_2xa2>
-color6       #<wallbash_2xa3>
-color14      #<wallbash_2xa3>
+    # Commands
+color2       #<wallbash_txt0>
+ 
+    # Prompt
 color7       #<wallbash_pry2>
-color15      #<wallbash_pry2>
+color4       #<wallbash_2xa4>
+color0       #<wallbash_txt2>
+
+    # Color Overrides
+# color1       #<wallbash_txt1>
+# color3       #<wallbash_1xa3>
+# color5       #<wallbash_2xa2>
+# color6       #<wallbash_2xa3>
+# color8       #<wallbash_1xa2>
+# color9       #<wallbash_pry1>
+# color10      #<wallbash_2xa4>
+# color11      #<wallbash_1xa3>
+# color12      #<wallbash_2xa1>
+# color13      #<wallbash_2xa2>
+# color14      #<wallbash_2xa3>
+# color15      #<wallbash_pry2>

--- a/Configs/.config/hypr/wallbash/kitty.dcol
+++ b/Configs/.config/hypr/wallbash/kitty.dcol
@@ -1,6 +1,6 @@
 $HOME/.config/kitty/themes/Wall-Dcol.conf|${ScrDir}/wallbashkitty.sh
-foreground         #<wallbash_pry2>
-background         #<wallbash_0xa1>
+foreground         #<wallbash_txt0>
+background         #<wallbash_pry0>
 cursor             #<wallbash_txt1> 
 
 active_tab_foreground     #<wallbash_pry0>


### PR DESCRIPTION
Commented out some color override as these are critical on terminal
 
Goal of this change is to give clarity. 

Based of zsh
+ The prompt uses colors [ 7 , 4 , 0  ]
![image](https://github.com/prasanthrangan/hyprdots/assets/53417443/7a90a753-081d-44bd-b0fc-a7552f4b8bd9)
 
+ The commands and executables is color [ 2 ]
![image](https://github.com/prasanthrangan/hyprdots/assets/53417443/43b887e1-d146-4e15-8f22-b4541343907f)

+ Here's some overrides for the color.
![image](https://github.com/prasanthrangan/hyprdots/assets/53417443/7d1b359a-98f0-4ac4-89d1-3237e6552f43)

WARNINGS, ERRORS, ALERTS are not visible if we override these colors.
Visibility in Terminal is vital, therefore I commented out these colors. 
 
```
color1 
color3 
color5 
color6 
color8 
color9 
color10
color11
color12
color13
color14
color15
```


##### Also tries to tweak for fish compatibility.  

![image](https://github.com/prasanthrangan/hyprdots/assets/53417443/224f5464-bb7e-4a62-9ef6-49873a95ce52)


My bad for this frequent change. 