### PR TITLE
Support for Ryzen CPU's 

### DIFF
--- a/Configs/.config/hypr/scripts/cpuinfo.sh
+++ b/Configs/.config/hypr/scripts/cpuinfo.sh
@@ -12,7 +12,13 @@ maxfreq=$(lscpu | grep "CPU max MHz" | awk -F: '{ print $2}' | sed -e 's/ //g' -
 frequency=$(echo $freqlist | tr ' ' '\n' | awk "{ sum+=\$1 } END {printf \"%.0f/$maxfreq MHz\", sum/NR}")
 
 # CPU temp
-temp=$(sensors | grep "Package id 0" | awk -F '[+.]' '{print $2}')
+temp=$(sensors | awk '/Package id 0/ {print $4}' | awk -F '[+.]' '{print $2}')
+if [ -z "$temp" ]; then
+    temp=$(sensors | awk '/Tctl/ {print $2}' | tr -d '+°C')
+fi
+if [ -z "$temp" ]; then
+    temp="N/A"
+fi
 
 # map icons
 set_ico="{\"thermo\":{\"0\":\"\",\"45\":\"\",\"65\":\"\",\"85\":\"\"},\"emoji\":{\"0\":\"❄\",\"45\":\"☁\",\"65\":\"\",\"85\":\"\"},\"util\":{\"0\":\"󰾆\",\"30\":\"󰾅\",\"60\":\"󰓅\",\"90\":\"\"}}"


### PR DESCRIPTION
# Pull Request

## Description

Added support for Ryzen CPU on Waybar module "cpuinfo.sh"

Waybar module for CPU temp returning: "Null" for Package ID 0 as Package ID 0 is not present for Ryzen series CPU's.

## Type of change

Please put an `x` in the boxes that apply:

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.
