### PR TITLE
perf: optimize performance of waybar cpuinfo and gpuinfo modules

### DIFF
--- a/Configs/.config/hypr/scripts/cpuinfo.sh
+++ b/Configs/.config/hypr/scripts/cpuinfo.sh
@@ -1,45 +1,46 @@
 #!/bin/bash
 
-get_icons() {
-    
-    # Thee shalt find the greatest one,
-    # He who not more than the chosen one
-    map_floor() {
 
-        # From the depths of the string, words arise,
-        # Keys in pairs, a treasure in disguise.
-        IFS=', ' read -r -a pairs <<< "$1"
+# Thee shalt find the greatest one,
+# He who not more than the chosen one
+map_floor() {
 
-        # If the final token stands alone and bold,
-        # Declare it the default, its worth untold.
-        if [[ ${pairs[-1]} != *":"* ]]; then
-            def_val="${pairs[-1]}"
-            unset 'pairs[${#pairs[@]}-1]'
+    # From the depths of the string, words arise,
+    # Keys in pairs, a treasure in disguise.
+    IFS=', ' read -r -a pairs <<< "$1"
+
+    # If the final token stands alone and bold,
+    # Declare it the default, its worth untold.
+    if [[ ${pairs[-1]} != *":"* ]]; then
+        def_val="${pairs[-1]}"
+        unset 'pairs[${#pairs[@]}-1]'
+    fi
+
+    # Scans the map, a peak it seeks,
+    # The highest passed, the value speaks.
+    for pair in "${pairs[@]}"; do
+        IFS=':' read -r key value <<< "$pair"
+        
+        # Behold! Thou holds the secrets they seek,
+        # Declare it and silence the whispers unique.
+        if [ ${2%%.*} -gt $key ]; then
+            echo "$value"
+            return
         fi
+    done
 
-        # Scans the map, a peak it seeks,
-        # The highest passed, the value speaks.
-        for pair in "${pairs[@]}"; do
-            IFS=':' read -r key value <<< "$pair"
-            
-            # Behold! Thou holds the secrets they seek,
-            # Declare it and silence the whispers unique.
-            if [ ${2%%.*} -gt $key ]; then
-                echo "$value"
-                return
-            fi
-        done
-
-        # On this lonely shore, where silence dwells
-        # Even the waves, echoes words unheard
-        [ -n "$def_val" ] && echo $def_val || echo " "
-    }
-
-    temp_lv="85:🌋, 65:🔥, 45:☁️, ❄️"
-    util_lv="90:, 60:󰓅, 30:󰾅, 󰾆" 
-
-    echo "$(map_floor "$util_lv" $2)$(map_floor "$temp_lv" $1)"
+    # On this lonely shore, where silence dwells
+    # Even the waves, echoes words unheard
+    [ -n "$def_val" ] && echo $def_val || echo " "
 }
+
+# Define glyphs
+if [[ $NO_EMOJI -eq 1 ]]; then
+    temp_lv="85:, 65:, 45:☁, ❄"
+else
+    temp_lv="85:🌋, 65:🔥, 45:☁️, ❄️"
+fi
+util_lv="90:, 60:󰓅, 30:󰾅, 󰾆" 
 
 # Get static CPU information
 model=$(lscpu | awk -F': ' '/Model name/ {gsub(/^ *| *$| CPU.*/,"",$2); print $2}')
@@ -64,7 +65,7 @@ while true; do
     frequency=$(cat /proc/cpuinfo | awk '/cpu MHz/{ sum+=$4; c+=1 } END { printf "%.0f", sum/c }')
 
     # Generate glyphs
-    icons=$(get_icons "$temperature" "$utilization")
+    icons=$(echo "$(map_floor "$util_lv" $utilization)$(map_floor "$temp_lv" $temperature)")
     speedo=$(echo ${icons:0:1})
     thermo=$(echo ${icons:1:1})
     emoji=$(echo ${icons:2})

--- a/Configs/.config/hypr/scripts/gpuinfo.sh
+++ b/Configs/.config/hypr/scripts/gpuinfo.sh
@@ -135,22 +135,21 @@ map_floor() {
     [ -n "$def_val" ] && echo $def_val || echo " "
 }
 
-generate_json() {
-  # Define glyphs
-  if [[ $NO_EMOJI -eq 1 ]]; then
-      temp_lv="85:, 65:, 45:☁, ❄"
-  else
-      temp_lv="85:🌋, 65:🔥, 45:☁️, ❄️"
-  fi
-  util_lv="90:, 60:󰓅, 30:󰾅, 󰾆" 
+# Define glyphs
+if [[ $NO_EMOJI -eq 1 ]]; then
+    temp_lv="85:, 65:, 45:☁, ❄"
+else
+    temp_lv="85:🌋, 65:🔥, 45:☁️, ❄️"
+fi
+util_lv="90:, 60:󰓅, 30:󰾅, 󰾆" 
 
+generate_json() {
   # Generate glyphs
-  icons=$(echo "$(map_floor "$util_lv" $2)$(map_floor "$temp_lv" $1)")
+  icons=$(echo "$(map_floor "$util_lv" $utilization)$(map_floor "$temp_lv" $temperature)")
   speedo=$(echo ${icons:0:1})
   thermo=$(echo ${icons:1:1})
   emoji=$(echo ${icons:2})
 
-  # emoji=$(get_temperature_emoji "${temperature}")
   local json="{\"text\":\"${thermo} ${temperature}°C\", \"tooltip\":\"${primary_gpu}\n${thermo} Temperature: ${temperature}°C ${emoji}"
 #? Soon Add Something incase needed.
   declare -A tooltip_parts

--- a/Configs/.config/hypr/scripts/gpuinfo.sh
+++ b/Configs/.config/hypr/scripts/gpuinfo.sh
@@ -102,50 +102,50 @@ sed -i "s/^#${next_prioGPU}/${next_prioGPU}/" "${gpuQ}" # Uncomment the next pri
 sed -i "s/prioGPU=${prioGPU}/prioGPU=${next_prioGPU}/" "${gpuQ}" # Update the prioGPU in the file
 }
 
-get_icons() {
+# Thee shalt find the greatest one,
+# He who not more than the chosen one
+map_floor() {
 
-    # Thee shalt find the greatest one,
-    # He who not more than the chosen one
-    map_floor() {
+    # From the depths of the string, words arise,
+    # Keys in pairs, a treasure in disguise.
+    IFS=', ' read -r -a pairs <<< "$1"
 
-        # From the depths of the string, words arise,
-        # Keys in pairs, a treasure in disguise.
-        IFS=', ' read -r -a pairs <<< "$1"
+    # If the final token stands alone and bold,
+    # Declare it the default, its worth untold.
+    if [[ ${pairs[-1]} != *":"* ]]; then
+        def_val="${pairs[-1]}"
+        unset 'pairs[${#pairs[@]}-1]'
+    fi
 
-        # If the final token stands alone and bold,
-        # Declare it the default, its worth untold.
-        if [[ ${pairs[-1]} != *":"* ]]; then
-            def_val="${pairs[-1]}"
-            unset 'pairs[${#pairs[@]}-1]'
+    # Scans the map, a peak it seeks,
+    # The highest passed, the value speaks.
+    for pair in "${pairs[@]}"; do
+        IFS=':' read -r key value <<< "$pair"
+        
+        # Behold! Thou holds the secrets they seek,
+        # Declare it and silence the whispers unique.
+        if [ ${2%%.*} -gt $key ]; then
+            echo "$value"
+            return
         fi
+    done
 
-        # Scans the map, a peak it seeks,
-        # The highest passed, the value speaks.
-        for pair in "${pairs[@]}"; do
-            IFS=':' read -r key value <<< "$pair"
-            
-            # Behold! Thou holds the secrets they seek,
-            # Declare it and silence the whispers unique.
-            if [ ${2%%.*} -gt $key ]; then
-                echo "$value"
-                return
-            fi
-        done
-
-        # On this lonely shore, where silence dwells
-        # Even the waves, echoes words unheard
-        [ -n "$def_val" ] && echo $def_val || echo " "
-    }
-
-    temp_lv="85:🌋, 65:🔥, 45:☁️, ❄️"
-    util_lv="90:, 60:󰓅, 30:󰾅, 󰾆" 
-
-    echo "$(map_floor "$util_lv" $2)$(map_floor "$temp_lv" $1)"
+    # On this lonely shore, where silence dwells
+    # Even the waves, echoes words unheard
+    [ -n "$def_val" ] && echo $def_val || echo " "
 }
 
 generate_json() {
-  # get emoji and icon based on temperature and utilization
-  icons=$(get_icons "$temperature" "$utilization")
+  # Define glyphs
+  if [[ $NO_EMOJI -eq 1 ]]; then
+      temp_lv="85:, 65:, 45:☁, ❄"
+  else
+      temp_lv="85:🌋, 65:🔥, 45:☁️, ❄️"
+  fi
+  util_lv="90:, 60:󰓅, 30:󰾅, 󰾆" 
+
+  # Generate glyphs
+  icons=$(echo "$(map_floor "$util_lv" $2)$(map_floor "$temp_lv" $1)")
   speedo=$(echo ${icons:0:1})
   thermo=$(echo ${icons:1:1})
   emoji=$(echo ${icons:2})

--- a/Configs/.config/hypr/scripts/gpuinfo.sh
+++ b/Configs/.config/hypr/scripts/gpuinfo.sh
@@ -102,57 +102,53 @@ sed -i "s/^#${next_prioGPU}/${next_prioGPU}/" "${gpuQ}" # Uncomment the next pri
 sed -i "s/prioGPU=${prioGPU}/prioGPU=${next_prioGPU}/" "${gpuQ}" # Update the prioGPU in the file
 }
 
-# Thee shalt find the greatest one,
-# He who not more than the chosen one
-map_floor() {
-
-    # From the depths of the string, words arise,
-    # Keys in pairs, a treasure in disguise.
-    IFS=', ' read -r -a pairs <<< "$1"
-
-    # If the final token stands alone and bold,
-    # Declare it the default, its worth untold.
-    if [[ ${pairs[-1]} != *":"* ]]; then
-        def_val="${pairs[-1]}"
-        unset 'pairs[${#pairs[@]}-1]'
-    fi
-
-    # Scans the map, a peak it seeks,
-    # The highest passed, the value speaks.
-    for pair in "${pairs[@]}"; do
-        IFS=':' read -r key value <<< "$pair"
-        
-        # Behold! Thou holds the secrets they seek,
-        # Declare it and silence the whispers unique.
-        if awk -v num="$2" -v k="$key" 'BEGIN { exit !(num > k) }'; then
-            echo "$value"
-            return
-        fi
-    done
-
-    # On this lonely shore, where silence dwells
-    # Even the waves, echoes words unheard
-    [ -n "$def_val" ] && echo $def_val || echo " "
-}
-
-# generate emoji and icon based on temperature and utilization
 get_icons() {
-    # key-value pairs of temperature and utilization levels
-    temp_lv="85:&🌋, 65:&🔥, 45:&☁️, &❄️"
+
+    # Thee shalt find the greatest one,
+    # He who not more than the chosen one
+    map_floor() {
+
+        # From the depths of the string, words arise,
+        # Keys in pairs, a treasure in disguise.
+        IFS=', ' read -r -a pairs <<< "$1"
+
+        # If the final token stands alone and bold,
+        # Declare it the default, its worth untold.
+        if [[ ${pairs[-1]} != *":"* ]]; then
+            def_val="${pairs[-1]}"
+            unset 'pairs[${#pairs[@]}-1]'
+        fi
+
+        # Scans the map, a peak it seeks,
+        # The highest passed, the value speaks.
+        for pair in "${pairs[@]}"; do
+            IFS=':' read -r key value <<< "$pair"
+            
+            # Behold! Thou holds the secrets they seek,
+            # Declare it and silence the whispers unique.
+            if [ ${2%%.*} -gt $key ]; then
+                echo "$value"
+                return
+            fi
+        done
+
+        # On this lonely shore, where silence dwells
+        # Even the waves, echoes words unheard
+        [ -n "$def_val" ] && echo $def_val || echo " "
+    }
+
+    temp_lv="85:🌋, 65:🔥, 45:☁️, ❄️"
     util_lv="90:, 60:󰓅, 30:󰾅, 󰾆" 
 
-    # return comma seperated emojis/icons 
-    icons=$(map_floor "$temp_lv" $1 | sed "s/&/,/")
-    icons="$icons,$(map_floor "$util_lv" $2)"
-    echo $icons
+    echo "$(map_floor "$util_lv" $2)$(map_floor "$temp_lv" $1)"
 }
 
 generate_json() {
   # get emoji and icon based on temperature and utilization
   icons=$(get_icons "$temperature" "$utilization")
-  thermo=$(echo $icons | awk -F, '{print $1}')
-  emoji=$(echo $icons | awk -F, '{print $2}')
-  speedo=$(echo $icons | awk -F, '{print $3}')
+  speedo=$(echo ${icons:0:1})
+  thermo=$(echo ${icons:1:1})
+  emoji=$(echo ${icons:2})
 
   # emoji=$(get_temperature_emoji "${temperature}")
   local json="{\"text\":\"${thermo} ${temperature}°C\", \"tooltip\":\"${primary_gpu}\n${thermo} Temperature: ${temperature}°C ${emoji}"

--- a/Configs/.config/hypr/scripts/gpuinfo.sh
+++ b/Configs/.config/hypr/scripts/gpuinfo.sh
@@ -4,6 +4,8 @@
 gpuQ="/tmp/hyprdots-${UID}-gpuinfo-query"
 tired=false
 [[ " $* " =~ " tired " ]] && ! grep -q "tired" "${gpuQ}" && echo "tired=true" >>"${gpuQ}"
+[[ " $* " =~ " no_emoji " ]] && ! grep -q "NO_EMOJI" "${gpuQ}" && echo "NO_EMOJI=1" >>"${gpuQ}"
+
 if [[ ! " $* " =~ " startup " ]]; then
    gpuQ="${gpuQ}$2"
 fi
@@ -135,14 +137,6 @@ map_floor() {
     [ -n "$def_val" ] && echo $def_val || echo " "
 }
 
-# Define glyphs
-if [[ $NO_EMOJI -eq 1 ]]; then
-    temp_lv="85:, 65:, 45:☁, ❄"
-else
-    temp_lv="85:🌋, 65:🔥, 45:☁️, ❄️"
-fi
-util_lv="90:, 60:󰓅, 30:󰾅, 󰾆" 
-
 generate_json() {
   # Generate glyphs
   icons=$(echo "$(map_floor "$util_lv" $utilization)$(map_floor "$temp_lv" $temperature)")
@@ -267,12 +261,21 @@ Avalable GPU: ${gpu_flags//_flag/}
 [flags]
 tired            * Adding this option will not query nvidia-smi if gpu is in suspend mode 
 startup          * Useful if you want a certain GPU to be set at startup
+no_emoji         * Use glyphs instead of emoji
 
 * If ${USER} declared env = WLR_DRM_DEVICES on hyprland then use this as the primary GPU
 EOF
 exit
     ;;
 esac
+
+# Define glyphs
+if [[ $NO_EMOJI -eq 1 ]]; then
+    temp_lv="85:, 65:, 45:☁, ❄"
+else
+    temp_lv="85:🌋, 65:🔥, 45:☁️, ❄️"
+fi
+util_lv="90:, 60:󰓅, 30:󰾅, 󰾆" 
 
 nvidia_flag=${nvidia_flag:-0} intel_flag=${intel_flag:-0} amd_flag=${amd_flag:-0}
 #? Based on the flags, call the corresponding function multi flags means multi GPU.

--- a/Configs/.config/waybar/modules/cpuinfo.jsonc
+++ b/Configs/.config/waybar/modules/cpuinfo.jsonc
@@ -2,7 +2,7 @@
         "exec": " ~/.config/hypr/scripts/cpuinfo.sh",
         "return-type": "json",
         "format": "{}",
-        "interval": 5, // once every 5 seconds
+        "restart-interval": 5, // once every 5 seconds
         "tooltip": true,
         "max-length": 1000
     },

--- a/Configs/.config/waybar/modules/cpuinfo.jsonc
+++ b/Configs/.config/waybar/modules/cpuinfo.jsonc
@@ -1,5 +1,5 @@
     "custom/cpuinfo": {
-        "exec": " ~/.config/hypr/scripts/cpuinfo.sh",
+        "exec": "NO_EMOJI=1 ~/.config/hypr/scripts/cpuinfo.sh",
         "return-type": "json",
         "format": "{}",
         "restart-interval": 5, // once every 5 seconds

--- a/Configs/.config/waybar/modules/gpuinfo.jsonc
+++ b/Configs/.config/waybar/modules/gpuinfo.jsonc
@@ -1,5 +1,5 @@
     "custom/gpuinfo": {
-        "exec": " ~/.config/hypr/scripts/gpuinfo.sh",
+        "exec": "NO_EMOJI=1 ~/.config/hypr/scripts/gpuinfo.sh",
         "return-type": "json",
         "format": "{}",
         "interval": 5, // once every 5 seconds
@@ -9,7 +9,7 @@
     },
 
     "custom/gpuinfo#nvidia": {
-        "exec": " ~/.config/hypr/scripts/gpuinfo.sh --use nvidia ",
+        "exec": "NO_EMOJI=1 ~/.config/hypr/scripts/gpuinfo.sh --use nvidia ",
         "return-type": "json",
         "format": "{}",
         "interval": 5, // once every 5 seconds
@@ -18,7 +18,7 @@
     },
 
     "custom/gpuinfo#amd": {
-        "exec": " ~/.config/hypr/scripts/gpuinfo.sh --use amd ",
+        "exec": "NO_EMOJI=1 ~/.config/hypr/scripts/gpuinfo.sh --use amd ",
         "return-type": "json",
         "format": "{}",
         "interval": 5, // once every 5 seconds
@@ -27,7 +27,7 @@
     },
 
     "custom/gpuinfo#intel": {
-        "exec": " ~/.config/hypr/scripts/gpuinfo.sh --use intel ",
+        "exec": "NO_EMOJI=1 ~/.config/hypr/scripts/gpuinfo.sh --use intel ",
         "return-type": "json",
         "format": "{}",
         "interval": 5, // once every 5 seconds


### PR DESCRIPTION
## Icon generation bottleneck

The function to generate icons have been causing performance bottleneck since the beginning of cpuinfo module.  The original version (3cf5d2971ba43a71c95bde8c3ec67858dfa12ed2, `c.sh` in the screenshot) has been taking around 30.5ms (not absolute, for comparison).

To reduce the performance overhead, the revision (9b9b1ce8cdd5914f243f62f19d38c6c2d457fd8b, `d.sh` in the screenshot) have improved the speed to 22.3ms (**37% faster** than the original version). Here a single `jq` has been used to replace multiple forks of `awk` to improve the performance. 

![image](https://github.com/prasanthrangan/hyprdots/assets/76743829/cfd66289-e841-4eb2-a275-8f8c8861b82d)

The original version turns out to run on 6.58ms (**364% faster** than original and **238% faster** than the revised) after minimizing the number of forks and removing all forks to `awk`  (`b.sh` in the screenshot).  I also tested possibly the minimal version `a.sh` which contains only if branches completed in 5.4ms.

![image](https://github.com/prasanthrangan/hyprdots/assets/76743829/59133eff-f73c-480f-9639-afc4601bc5bf)

Despite `a.sh` is the fastest, I included `b.sh` in both gpuinfo and cpuinfo as it follows Object Oriented principles and performance difference is insignificant (1.18ms). 

## The forks

There are a number of redundant forks throughout script like:
`maxfreq=$(lscpu | grep "CPU max MHz" | awk -F: '{ print $2}' | sed -e 's/ //g' -e 's/\.[0-9]*//g')`

Which could be improved by substituting with:
`maxfreq=$(lscpu | awk '/CPU max MHz/ { sub(/\..*/,"",$4); print $4}')`

The number of forks have been minimized completely on `cpuinfo.sh` and partially on `gpuinfo.sh`.

## `top` bottleneck

The overall performance of the script wasn't improved significantly even after minimizing forks as the `top -bn1` taking almost **260ms** as it has to compute information of all running and sleeping processes.  The utility `mpstat` is a great alternative but it requires the program to be installed on the system. Hence `top` is replaced by calculating the utilization levels directly from `/proc/stat` which is taking around **15ms**, that is **1633%** improvement in performance.

## Continuous script

As the script has to recalculate values that doesn't change during runtime (like CPU name and max freq), it is inefficient to run on every 5s. Since waybar allows the scripts to be executed in continuous mode which allows significant improvement on performance as the static values doesn't required to be recalculated on each iteration, the cpuinfo.sh has been adjusted to run as a continuous script.

## Other changes

Improved accuracy of utilization level as it now prints average between each updates. Also added option to decide whether to print emojis or glyphs by setting an environment variable `NO_EMOJI` as the commit: 9b9b1ce8cdd5914f243f62f19d38c6c2d457fd8b converted emojis to glyphs.

## Warning to reviewers

The changes included in the commit: a5cfdd0f3f5a94f8dfa0ef4fc27dffbc973a6097 have been included in this PR, but haven't tested as my machine doesn't have AMD CPU. Although, I tried testing with passing faked sensors data and worked well.

## Testing

All the unit testing has been done by the script:

`python -m timeit -n 10 -s 'import subprocess' "subprocess.call('./test.sh', shell=True)"`

The `python timeit` is not absolute but is highly precise and useful for comparison. I think `strace` or `time` gives more accurate results but are not statistical or precise.

## Type of change

- [x] **Performance improvement** (non-breaking change)
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
