### PR TITLE
Temporarily Turning off hyprshade while taking screenshot

### DIFF
--- a/Configs/.config/hypr/scripts/screenshot.sh
+++ b/Configs/.config/hypr/scripts/screenshot.sh
@@ -1,10 +1,26 @@
 #!/usr/bin/env sh
 
-if [ -z "$XDG_PICTURES_DIR" ] ; then
-    XDG_PICTURES_DIR="$HOME/Pictures"
+# Restores the shader after screenhot has been taken
+restore_shader() {
+	if [ -n "$shader" ]; then
+		hyprshade on "$shader"
+	fi
+}
+
+# Saves the current shader and turns it off
+save_shader() {
+	shader=$(hyprshade current)
+	hyprshade off
+	trap restore_shader EXIT
+}
+
+save_shader # Saving the current shader
+
+if [ -z "$XDG_PICTURES_DIR" ]; then
+	XDG_PICTURES_DIR="$HOME/Pictures"
 fi
 
-ScrDir=`dirname "$(realpath "$0")"`
+ScrDir=$(dirname "$(realpath "$0")")
 source $ScrDir/globalcontrol.sh
 swpy_dir="${XDG_CONFIG_HOME:-$HOME/.config}/swappy"
 save_dir="${2:-$XDG_PICTURES_DIR/Screenshots}"
@@ -13,11 +29,11 @@ temp_screenshot="/tmp/screenshot.png"
 
 mkdir -p $save_dir
 mkdir -p $swpy_dir
-echo -e "[Default]\nsave_dir=$save_dir\nsave_filename_format=$save_file" > $swpy_dir/config
+echo -e "[Default]\nsave_dir=$save_dir\nsave_filename_format=$save_file" >$swpy_dir/config
 
 function print_error
 {
-cat << "EOF"
+	cat <<"EOF"
     ./screenshot.sh <action>
     ...valid actions are...
         p : print all screens
@@ -28,21 +44,20 @@ EOF
 }
 
 case $1 in
-p)  # print all outputs
-    grimblast copysave screen $temp_screenshot && swappy -f $temp_screenshot ;;
-s)  # drag to manually snip an area / click on a window to print it
-    grimblast copysave area $temp_screenshot && swappy -f $temp_screenshot ;;
-sf)  # frozen screen, drag to manually snip an area / click on a window to print it
-    grimblast --freeze copysave area $temp_screenshot && swappy -f $temp_screenshot ;;
-m)  # print focused monitor
-    grimblast copysave output $temp_screenshot && swappy -f $temp_screenshot ;;
-*)  # invalid option
-    print_error ;;
+p) # print all outputs
+	grimblast copysave screen $temp_screenshot && restore_shader && swappy -f $temp_screenshot ;;
+s) # drag to manually snip an area / click on a window to print it
+	grimblast copysave area $temp_screenshot && restore_shader && swappy -f $temp_screenshot ;;
+sf) # frozen screen, drag to manually snip an area / click on a window to print it
+	grimblast --freeze copysave area $temp_screenshot && restore_shader && swappy -f $temp_screenshot ;;
+m) # print focused monitor
+	grimblast copysave output $temp_screenshot && restore_shader && swappy -f $temp_screenshot ;;
+*) # invalid option
+	print_error ;;
 esac
 
 rm "$temp_screenshot"
 
-if [ -f "$save_dir/$save_file" ] ; then
-    dunstify "t1" -a "saved in $save_dir" -i "$save_dir/$save_file" -r 91190 -t 2200
+if [ -f "$save_dir/$save_file" ]; then
+	dunstify "t1" -a "saved in $save_dir" -i "$save_dir/$save_file" -r 91190 -t 2200
 fi
-


### PR DESCRIPTION
# Pull Request

Turning off Hyprshade while taking Screenshot, this may come in handy if using nightlight to remove double layyer of hyprshade

## Type of change
Added a current Hyprshade config remembering script 
oes not fix a bug or add a feature but makes something clearer for devs)
- [ x] **Other** 

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have added necessary comments/documentation to my code.
- [x] I have tested my code locally and it works as expected.


## Screenshots
Before 
![2024-02-26T19:59:37,428987443+05:30](https://github.com/prasanthrangan/hyprdots/assets/94917588/b1d56f31-62fe-4d1e-accf-67517f7fde2d)

After 
![image](https://github.com/prasanthrangan/hyprdots/assets/94917588/a76e1f06-1de5-43d7-b90a-041f48f120d9)

## Additional context
This won't affect the people who don't have hyprshade 
