### PR TITLE
Create cached if no 'code'

### DIFF
--- a/Scripts/create_cache.sh
+++ b/Scripts/create_cache.sh
@@ -151,11 +151,13 @@ do
     echo "Creating thumbnails for ${theme} [${#wpArray[@]}]"
     parallel --bar imagick_t2 ::: "${theme}" ::: "${wpArray[@]}"
 
+if pkg_installed code ; then
     if [ ! -z "$(echo $ctlLine | awk -F '|' '{print $3}')" ] ; then
         codex=$(echo $ctlLine | awk -F '|' '{print $3}' | cut -d '~' -f 1)
         if [ $(code --list-extensions |  grep -iwc "${codex}") -eq 0 ] ; then
-            code --install-extension "${codex}" 2> /dev/null
+            code --install-extension "${codex}" 2> /dev/null || true
         fi
     fi
-done
+fi
 
+done


### PR DESCRIPTION
# Pull Request

## Description

Some users do not use code and deleted it. 
Also, if it is okay, I added '|| true' upon ext installation as this gives an exit status but no error messages. Which leads to user needs to run ./install.sh for every theme.(Maybe connectivity issue). The extension still be added by running ``` create_cache.sh ``` again. (faster than full ./install.sh) 




Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)


