### PR TITLE
gpuinfo.sh: use limit instead of max_limit for nvidia-smi PL query

### DIFF
--- a/Configs/.config/hyprdots/scripts/gpuinfo.sh
+++ b/Configs/.config/hyprdots/scripts/gpuinfo.sh
@@ -212,7 +212,7 @@ if ${tired}; then is_suspend="$(cat /sys/bus/pci/devices/0000:"${nvidia_address}
    if [[ ${is_suspend} == *"suspend"* ]]; then
       printf '{"text":"󰤂", "tooltip":"%s ⏾ Suspended mode"}' "${primary_gpu}"; exit ;fi
 fi
-  gpu_info=$(nvidia-smi --query-gpu=temperature.gpu,utilization.gpu,clocks.current.graphics,clocks.max.graphics,power.draw,power.max_limit --format=csv,noheader,nounits)
+  gpu_info=$(nvidia-smi --query-gpu=temperature.gpu,utilization.gpu,clocks.current.graphics,clocks.max.graphics,power.draw,power.limit --format=csv,noheader,nounits)
   # Split the comma-separated values into an array
   IFS=',' read -ra gpu_data <<< "${gpu_info}"
   # Extract individual values


### PR DESCRIPTION
# Pull Request

## Description

Currently, the script gets the max power limit, which is usually not active by default. With this change, it will get the currently active power limit, which should show more accurate power usage information.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

Feedback very welcome.