### PR TITLE
Fix: Added packages needed for "open with" in dolphin

### DIFF
--- a/Scripts/custom_hypr.lst
+++ b/Scripts/custom_hypr.lst
@@ -54,13 +54,6 @@ kdbusaddons5                                           # for "open with" menu in
 kfilemetadata5                                          # for "open with" menu in dolphin
 kconfig5                                                # for "open with" menu in dolphin
 kcoreaddons5                                           # for "open with" menu in dolphin
-kcrash5                                                # for "open with" menu in dolphin
-kguiaddons5                                            # for "open with" menu in dolphin
-ki18n5                                                 # for "open with" menu in dolphin
-kitemviews5                                            # for "open with" menu in dolphin
-kwidgetsaddons5                                        # for "open with" menu in dolphin
-kwindowsystem5                                         # for "open with" menu in dolphin
-
 
 # --------------------------------------------------- // Theming
 nwg-look                                               # gtk configuration tool

--- a/Scripts/custom_hypr.lst
+++ b/Scripts/custom_hypr.lst
@@ -49,6 +49,18 @@ imagemagick                                            # for image processing
 qt5-imageformats                                       # for dolphin image thumbnails
 ffmpegthumbs                                           # for dolphin video thumbnails
 kde-cli-tools                                          # for dolphin file type defaults
+kservice5                                              # for "open with" menu in dolphin
+kdbusaddons5                                           # for "open with" menu in dolphin
+kfilemetadata5                                          # for "open with" menu in dolphin
+kconfig5                                                # for "open with" menu in dolphin
+kcoreaddons5                                           # for "open with" menu in dolphin
+kcrash5                                                # for "open with" menu in dolphin
+kguiaddons5                                            # for "open with" menu in dolphin
+ki18n5                                                 # for "open with" menu in dolphin
+kitemviews5                                            # for "open with" menu in dolphin
+kwidgetsaddons5                                        # for "open with" menu in dolphin
+kwindowsystem5                                         # for "open with" menu in dolphin
+kservice5                                              # for "open with" menu in dolphin
 
 
 # --------------------------------------------------- // Theming

--- a/Scripts/custom_hypr.lst
+++ b/Scripts/custom_hypr.lst
@@ -60,7 +60,6 @@ ki18n5                                                 # for "open with" menu in
 kitemviews5                                            # for "open with" menu in dolphin
 kwidgetsaddons5                                        # for "open with" menu in dolphin
 kwindowsystem5                                         # for "open with" menu in dolphin
-kservice5                                              # for "open with" menu in dolphin
 
 
 # --------------------------------------------------- // Theming

--- a/Scripts/custom_hypr.lst
+++ b/Scripts/custom_hypr.lst
@@ -50,10 +50,6 @@ qt5-imageformats                                       # for dolphin image thumb
 ffmpegthumbs                                           # for dolphin video thumbnails
 kde-cli-tools                                          # for dolphin file type defaults
 kservice5                                              # for "open with" menu in dolphin
-kdbusaddons5                                           # for "open with" menu in dolphin
-kfilemetadata5                                          # for "open with" menu in dolphin
-kconfig5                                                # for "open with" menu in dolphin
-kcoreaddons5                                           # for "open with" menu in dolphin
 
 
 # --------------------------------------------------- // Theming

--- a/Scripts/custom_hypr.lst
+++ b/Scripts/custom_hypr.lst
@@ -55,6 +55,7 @@ kfilemetadata5                                          # for "open with" menu i
 kconfig5                                                # for "open with" menu in dolphin
 kcoreaddons5                                           # for "open with" menu in dolphin
 
+
 # --------------------------------------------------- // Theming
 nwg-look                                               # gtk configuration tool
 qt5ct                                                  # qt5 configuration tool


### PR DESCRIPTION
# Pull Request

## Description

- Just added `kservice5 kdbusaddons5 kfilemetadata5 kconfig5 kcoreaddons5` to fix "open with" menu in dolphin

- I had an issue where I couldn't see any apps in "open with" and files couldn't be opened with vscode (which is the default app), other file managers could open it with no issues.

- Installing those packages fixed the problem.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [X] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [X] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.