### PR TITLE
[Wallbash] Skip non existing Target file

### DIFF
--- a/Configs/.config/hyprdots/scripts/swwwallbash.sh
+++ b/Configs/.config/hyprdots/scripts/swwwallbash.sh
@@ -36,7 +36,7 @@ fi
 fn_wallbash () {
     local tplt="${1}"
     eval target=$(head -1 "${tplt}" | awk -F '|' '{print $1}')
-    touch "${target}" || { echo "[skip] $(dirname "${target}")" && return 0 ;}
+    touch "${target}" &> /dev/null || { echo "[skip] $(dirname "${target}")" && return 0 ;}
     eval appexe=$(head -1 "${tplt}" | awk -F '|' '{print $2}')
     source "${ScrDir}/globalcontrol.sh"
     source "${wallbashOut}"

--- a/Configs/.config/hyprdots/scripts/swwwallbash.sh
+++ b/Configs/.config/hyprdots/scripts/swwwallbash.sh
@@ -36,6 +36,7 @@ fi
 fn_wallbash () {
     local tplt="${1}"
     eval target=$(head -1 "${tplt}" | awk -F '|' '{print $1}')
+    [ ! -e ${target} ] && return 0
     eval appexe=$(head -1 "${tplt}" | awk -F '|' '{print $2}')
     source "${ScrDir}/globalcontrol.sh"
     source "${wallbashOut}"

--- a/Configs/.config/hyprdots/scripts/swwwallbash.sh
+++ b/Configs/.config/hyprdots/scripts/swwwallbash.sh
@@ -36,7 +36,7 @@ fi
 fn_wallbash () {
     local tplt="${1}"
     eval target=$(head -1 "${tplt}" | awk -F '|' '{print $1}')
-    touch "${target}" || return 0
+    touch "${target}" || { echo "[skip] $(dirname "${target}")" && return 0 ;}
     eval appexe=$(head -1 "${tplt}" | awk -F '|' '{print $2}')
     source "${ScrDir}/globalcontrol.sh"
     source "${wallbashOut}"

--- a/Configs/.config/hyprdots/scripts/swwwallbash.sh
+++ b/Configs/.config/hyprdots/scripts/swwwallbash.sh
@@ -36,7 +36,7 @@ fi
 fn_wallbash () {
     local tplt="${1}"
     eval target=$(head -1 "${tplt}" | awk -F '|' '{print $1}')
-    [ ! -e ${target} ] && return 0
+    touch "${target}" || return 0
     eval appexe=$(head -1 "${tplt}" | awk -F '|' '{print $2}')
     source "${ScrDir}/globalcontrol.sh"
     source "${wallbashOut}"


### PR DESCRIPTION
# Fix

Will skip wallbash if directory of target file does not exist 

Example if directory ``` /home/khing/.config/cava/ ``` does not exist then skip wallbash for cava
Before: 
![image](https://github.com/prasanthrangan/hyprdots/assets/53417443/a8afdba7-2d00-4fc5-8fb4-4cfabf19471e)

After:
![image](https://github.com/prasanthrangan/hyprdots/assets/53417443/09755f05-2a10-4550-84bd-3efc22e2acbd)

> [!Note]
> Wallbash requirement:parent directory should exist for the target file .
