### PR TITLE
Gamemode.sh temporary fix for Hyprland V0.37.1.1

### DIFF
--- a/Configs/.config/hyprdots/scripts/gamemode.sh
+++ b/Configs/.config/hyprdots/scripts/gamemode.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env sh
-HYPRGAMEMODE=$(hyprctl getoption animations:enabled | sed -n '2p' | awk '{print $2}')
+HYPRGAMEMODE=$(hyprctl getoption animations:enabled | sed -n '1p' | awk '{print $2}')
 
 # Waybar performance
 FILE="$HOME/.config/waybar/style.css"
 
 sed -i 's/\/\* \(.*animation:.*\) \*\//\1/g' $FILE
+sed -i 's/\/\* \(.*transition:.*\) \*\//\1/g' $FILE
 if [ $HYPRGAMEMODE = 1 ]; then
-    sed -i 's/^\(.*animation:.*\)$/\/\* \1 \*\//g' $FILE
+	sed -i 's/^\(.*animation:.*\)$/\/\* \1 \*\//g' $FILE
+	sed -i 's/^\(.*transition:.*\)$/\/\* \1 \*\//g' $FILE
 fi
 killall waybar
-waybar > /dev/null 2>&1 &
+waybar >/dev/null 2>&1 &
 
 # Hyprland performance
-if [ $HYPRGAMEMODE = 1 ] ; then
-    hyprctl --batch "\
+if [ $HYPRGAMEMODE = 1 ]; then
+	hyprctl --batch "\
         keyword animations:enabled 0;\
         keyword decoration:drop_shadow 0;\
         keyword decoration:blur:enabled 0;\
@@ -21,6 +23,7 @@ if [ $HYPRGAMEMODE = 1 ] ; then
         keyword general:gaps_out 0;\
         keyword general:border_size 1;\
         keyword decoration:rounding 0"
-    exit
+	exit
+else
+	hyprctl reload
 fi
-hyprctl reload


### PR DESCRIPTION
# Pull Request

## Description
- Fix gamemode.sh won't do anything
- Disabled waybar transition when gamemode was enabled (due to uncanny effect)

## Type of change

- [x ] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

Please put an `x` in the boxes that apply:

- [ x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [ x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ x] I have tested my code locally and it works as expected.
- [x ] All new and existing tests passed.


## Additional context

The output for the hyprctl command seems to be changed and hyprctl reload was resetting the changes made by  hyprctl --batch 'command')
This may be an Hyprland bug but as of now this fix works