### PR TITLE
Change: Make user press key to continue in systemupdate.sh

### DIFF
--- a/Configs/.local/share/bin/systemupdate.sh
+++ b/Configs/.local/share/bin/systemupdate.sh
@@ -6,21 +6,21 @@ if [ ! -f /etc/arch-release ] ; then
 fi
 
 # source variables
-scrDir=`dirname "$(realpath "$0")"`
-source $scrDir/globalcontrol.sh
+scrDir=$(dirname "$(realpath "$0")")
+source "$scrDir/globalcontrol.sh"
 get_aurhlpr
 fpk_exup="flatpak update"
 
 # Trigger upgrade
 if [ "$1" == "up" ] ; then
-trap 'pkill -RTMIN+20 waybar' EXIT
-command="
-neofetch
-$0 upgrade
-${aurhlpr} -Syu 
-$fpk_exup
-read -t 5
-"
+    trap 'pkill -RTMIN+20 waybar' EXIT
+    command="
+    neofetch
+    $0 upgrade
+    ${aurhlpr} -Syu
+    $fpk_exup
+    read -n 1 -p 'Press any key to continue...'
+    "
     kitty --title systemupdate sh -c "${command}"
 fi
 
@@ -43,7 +43,7 @@ upd=$(( ofc + aur + fpk ))
 [ "${1}" == upgrade ] && printf "[Official] %-10s\n[AUR]      %-10s\n[Flatpak]  %-10s\n" "$ofc" "$aur" "$fpk" && exit
 
 # Show tooltip
- if [ $upd -eq 0 ] ; then
+if [ $upd -eq 0 ] ; then
     upd="" #Remove Icon completely
     # upd="󰮯"   #If zero Display Icon only
     echo "{\"text\":\"$upd\", \"tooltip\":\" Packages are up to date\"}"


### PR DESCRIPTION
# Pull Request

## Description

Make user press any key to continue the system update script. This is for allowing users to read pacman and flatpak update logs, which occasionally end up being useful to read.

Also did some minor formatting changes.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [x] **Other** (provide details below)
 - Minor formatting changes

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

![image](https://github.com/prasanthrangan/hyprdots/assets/139541046/17cd8b0d-3ca0-442e-9a03-598ae3455d31)
