### PR TITLE
 fix: systemupdate.sh with fastfetch

### DIFF
--- a/Configs/.local/share/bin/systemupdate.sh
+++ b/Configs/.local/share/bin/systemupdate.sh
@@ -15,7 +15,7 @@ fpk_exup="flatpak update"
 if [ "$1" == "up" ] ; then
     trap 'pkill -RTMIN+20 waybar' EXIT
     command="
-    neofetch
+    fastfetch
     $0 upgrade
     ${aurhlpr} -Syu
     $fpk_exup


### PR DESCRIPTION
# Pull Request

## Description

HyDE has transitioned to using fastfetch rather than neofetch by default.

This change allows the systemupdate.sh script to execute correctly on a system that does not have the 'neofetch' package.

Please read these instructions and remove unnecessary text.

- Try to include a summary of the changes and which issue is fixed.
- Also include relevant motivation and context (if applicable).
- List any dependencies that are required for this change. (e.g., packages or other PRs)
- Provide a link if there is an issue related to this pull request. e.g., Fixes # (issue)
- Please add Reviewers, Assignees, Labels, Projects, and Milestones to the PR. (if applicable)

## Type of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [X] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [X] I have tested my code locally and it works as expected.
- [X] All new and existing tests passed.

## Screenshots

## Additional context
