### PR TITLE
fix: install.sh stopping after detecting non-nvidia gpu

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -100,14 +100,12 @@ EOF
     #--------------------------------#
     # add nvidia drivers to the list #
     #--------------------------------#
-    if nvidia_detect; then
+    if nvidia_detect --verbose; then
         cat /usr/lib/modules/*/pkgbase | while read krnl; do
             echo "${krnl}-headers" >> "${scrDir}/install_pkg.lst"
         done
         nvidia_detect --drivers >> "${scrDir}/install_pkg.lst"
     fi
-
-    nvidia_detect --verbose
 
     #----------------#
     # get user prefs #


### PR DESCRIPTION
# Pull Request

## Description

Fixes an issue that stops the install script functioning after detecting a non-nvidia gpu.

Tested it working by telling the script i was running an nvidia gpu and it works fine.

Fixes: https://github.com/prasanthrangan/hyprdots/issues/1378

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
