### PR TITLE
Fixed certain clashing keybindings

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -24,14 +24,14 @@ bind = Alt, Return, fullscreen, # toggle the window between focus and fullscreen
 bind = $mainMod, L, exec, swaylock # launch lock screen
 bind = $mainMod+Shift, F, exec, $scrPath/windowpin.sh # toggle pin on focused window
 bind = $mainMod, Backspace, exec, $scrPath/logoutlaunch.sh # launch logout menu
-bind = Ctrl, Escape, exec, killall waybar || waybar # toggle waybar
+bind = Ctrl+Alt,W , exec, killall waybar || waybar # toggle waybar
 
 # Application shortcuts
 bind = $mainMod, T, exec, $term # launch terminal emulator
 bind = $mainMod, E, exec, $file # launch file manager
 bind = $mainMod, C, exec, $editor # launch text editor
 bind = $mainMod, F, exec, $browser # launch web browser
-bind = Ctrl+Shift, Escape, exec, $scrPath/sysmonlaunch.sh # launch system monitor (htop/btop or fallback to top)
+bind = Ctrl+Shift, Escape, exec, [centre;size 800 500;float] $scrPath/sysmonlaunch.sh # launch system monitor (htop/btop or fallback to top)
 
 # Rofi menus
 bind = $mainMod, A, exec, pkill -x rofi || $scrPath/rofilaunch.sh d # launch application launcher

--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -24,7 +24,7 @@ bind = Alt, Return, fullscreen, # toggle the window between focus and fullscreen
 bind = $mainMod, L, exec, swaylock # launch lock screen
 bind = $mainMod+Shift, F, exec, $scrPath/windowpin.sh # toggle pin on focused window
 bind = $mainMod, Backspace, exec, $scrPath/logoutlaunch.sh # launch logout menu
-bind = Ctrl+Alt,W , exec, killall waybar || waybar # toggle waybar
+bind = Ctrl+Alt, W, exec, killall waybar || waybar # toggle waybar
 
 # Application shortcuts
 bind = $mainMod, T, exec, $term # launch terminal emulator


### PR DESCRIPTION
# Pull Request

## Type of change

Please put an `x` in the boxes that apply:

- [x ] **Bug fix** (non-breaking change which fixes an issue)
- [ Maybe ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.

## Additional context

Add any other context about the problem here.

- fixing the keybind that causes the waybar to change state (killed/active) (discussed on https://github.com/kRHYME7/Hyde-cli/issues/22#issuecomment-2078778091 )
- Made the sysmon (btop/htop) floating.