### PR TITLE
Fixes some ENV block errors and ensure shell are run inside hyprland ENV

### DIFF
--- a/Configs/.config/waybar/modules/updates.jsonc
+++ b/Configs/.config/waybar/modules/updates.jsonc
@@ -3,9 +3,8 @@
         "return-type": "json",
         "format": "{}",
         "rotate": ${r_deg},
-        "on-click": "systemupdate.sh up",
+        "on-click": "hyprctl dispatch exec 'systemupdate.sh up'",
         "interval": 86400, // once every day
         "tooltip": true,
         "signal": 20,
     },
-

--- a/Configs/.local/share/bin/wallbashqt.sh
+++ b/Configs/.local/share/bin/wallbashqt.sh
@@ -18,6 +18,6 @@ a_ws=$(hyprctl -j activeworkspace | jq '.id')
 dpid=$(hyprctl -j clients | jq --arg wid "$a_ws" '.[] | select(.workspace.id == ($wid | tonumber)) | select(.class == "org.kde.dolphin") | .pid')
 if [ ! -z ${dpid} ] ; then
     hyprctl dispatch closewindow pid:${dpid}
-    dolphin &
+    hyprctl dispatch exec dolphin &
 fi
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes!

Some scripts don't have access/rights to some variables compared to when run with ` hyprctl dispatch exec ` .

Thanks to @hoodust  @Skerse  
