### PR TITLE
Change waybar style `min-height` to 16px for tray context menu to improve context menu icons

### DIFF
--- a/Configs/.config/waybar/modules/style.css
+++ b/Configs/.config/waybar/modules/style.css
@@ -86,6 +86,14 @@ tooltip {
     transition: all 0.3s cubic-bezier(.55,-0.68,.48,1.682);
 }
 
+#tray menu * {
+    min-height: 16px
+}
+
+#tray menu separator {
+    min-height: 10px
+}
+
 ${modules_ls}
 #custom-l_end,
 #custom-r_end,

--- a/Configs/.config/waybar/style.css
+++ b/Configs/.config/waybar/style.css
@@ -86,6 +86,14 @@ tooltip {
     transition: all 0.3s cubic-bezier(.55,-0.68,.48,1.682);
 }
 
+#tray menu * {
+    min-height: 16px
+}
+
+#tray menu separator {
+    min-height: 10px
+}
+
 #backlight,
 #battery,
 #bluetooth,


### PR DESCRIPTION
# Pull Request

## Description

Waybar context menus had malformed icons, it is not round (or square) but like oval (or rectangle).

1. Changing `min-height` in css improves icons making them look more pretty.
2. Additional `min-height` for separator prevents a menu separator to have increased height.

I have tested this change with different themes and font sizes (from 8 to 16) and didn't notice any problems

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

### Before
![image](https://github.com/prasanthrangan/hyprdots/assets/13994839/d3f3fbc5-dff7-475a-bc26-86859e5de732)

### After
![image](https://github.com/prasanthrangan/hyprdots/assets/13994839/de6f53d6-c99e-4882-92b7-656c28658006)

