### PR TITLE
fix: only use format '2' for gpu module

### DIFF
--- a/Configs/.config/fastfetch/config.jsonc
+++ b/Configs/.config/fastfetch/config.jsonc
@@ -66,6 +66,7 @@
         },
         {
             "type": "gpu",
+            "format": "{2}",
             "key": "   GPU",
             "keyColor": "blue"
         },


### PR DESCRIPTION
# Pull Request

## Description

I think fastfetch must have done a change that increased the amount of information the default gpu module gives? This just formats it to how it was before.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.

## Screenshots

As of right now: 
![image](https://github.com/prasanthrangan/hyprdots/assets/139541046/57012019-9330-4698-9bc5-62d2b0ba91a1)

With the format applied: 
![image](https://github.com/prasanthrangan/hyprdots/assets/139541046/99c5047f-7a59-4814-9f3b-0f7c58d0cb91)
