### PR TITLE
Adjusting the discord palette generator and fixing the invisible text

### DIFF
--- a/Configs/.config/hyde/wallbash/Wall-Ways/discord.dcol
+++ b/Configs/.config/hyde/wallbash/Wall-Ways/discord.dcol
@@ -11,9 +11,10 @@ ${cacheDir}/landing/discord.css|${scrDir}/wallbashdiscord.sh
 	--background-modifier-hover: #<wallbash_3xa4> !important;
 	--background-modifier-active: #<wallbash_4xa4> !important;
 	--text-normal: #<wallbash_txt1> !important;
-	--text-positive: #<wallbash_2xa9> !important;
-	--text-muted: #<wallbash_1xa9>66 !important;
-	--text-link: #<wallbash_4xa9> !important;
+	--text-positive: #<wallbash_3xa9> !important;
+	--text-muted: #<wallbash_txt1>66 !important;
+	--text-link: #<wallbash_pry4> !important;
+  --channel-default: #<wallbash_txt1>99 !important;
 	--button-background: #<wallbash_pry1> !important;
 	--button-background-hover: #<wallbash_pry1> !important;
 	--button-background-active: #<wallbash_pry1> !important;
@@ -29,18 +30,18 @@ ${cacheDir}/landing/discord.css|${scrDir}/wallbashdiscord.sh
 
 	--background-primary: var(--background-1);
 	--background-primary-alt: var(--background-1);
-	--background-secondary: var(--background-1);
-	--background-secondary-alt: var(--background-1);
+	--background-secondary: var(--background-tertiary);
+	--background-secondary-alt: var(--background-tertiary);
 	--background-accent-gradient: var(--background-1);
 	--background-floating: var(--background-2);
 	--background-modifier-selected: var(--accent-color);
 	--background-modifier-accent: var(--border-color);
 	--background-message-hover: transparent;
 	--interactive-selected: var(--background-primary);
-	--interactive-active: var(--text-normal);
+	--interactive-active: var(--text-positive);
 	--interactive-normal: var(--text-normal);
   --interactive-muted: var(--text-muted);
-	--channels-default: var(--text-normal);
+	--channels-default: var(--channel-default);
 	--header-primary: var(--text-normal);
 	--header-secondary: var(--text-muted);
 	--control-brand-foreground: var(--accent-color);

--- a/Configs/.config/hyde/wallbash/Wall-Ways/discord.dcol
+++ b/Configs/.config/hyde/wallbash/Wall-Ways/discord.dcol
@@ -1,13 +1,13 @@
 ${cacheDir}/landing/discord.css|${scrDir}/wallbashdiscord.sh
 
 :root {
-	--accent-color: #<wallbash_1xa2>;
-	--border-color: #<wallbash_pry1>;
+	--accent-color: #<wallbash_1xa1>;
+	--border-color: #<wallbash_pry3>;
 	--background-1: #<wallbash_pry1>;
 	--background-2: #<wallbash_1xa2>;
-	--background-tertiary: #<wallbash_1xa1>;
-	--background-mentioned: #<wallbash_1xa3> !important;
-	--background-mentioned-hover: #<wallbash_2xa4> !important;
+	--background-tertiary: #<wallbash_pry1>66;
+	--background-mentioned: #<wallbash_2xa3> !important;
+	--background-mentioned-hover: #<wallbash_2xa2> !important;
 	--background-modifier-hover: #<wallbash_3xa4> !important;
 	--background-modifier-active: #<wallbash_4xa4> !important;
 	--text-normal: #<wallbash_txt1> !important;
@@ -29,17 +29,16 @@ ${cacheDir}/landing/discord.css|${scrDir}/wallbashdiscord.sh
 
 	--background-primary: var(--background-1);
 	--background-primary-alt: var(--background-1);
-	--background-secondary: var(--background-tertiary);
-	--background-secondary-alt: var(--background-tertiary);
+	--background-secondary: var(--background-1);
+	--background-secondary-alt: var(--background-1);
 	--background-accent-gradient: var(--background-1);
 	--background-floating: var(--background-2);
 	--background-modifier-selected: var(--accent-color);
-	--background-modifier-accent: transparent;
+	--background-modifier-accent: var(--border-color);
 	--background-message-hover: transparent;
 	--interactive-selected: var(--background-primary);
 	--interactive-active: var(--text-normal);
 	--interactive-normal: var(--text-normal);
-	--interactive-muted: var(--button-background-active);
 	--channels-default: var(--text-muted);
 	--header-primary: var(--text-normal);
 	--header-secondary: var(--text-muted);
@@ -58,7 +57,7 @@ ${cacheDir}/landing/discord.css|${scrDir}/wallbashdiscord.sh
 	--scrollbar-auto-scrollbar-color-thumb: var(--accent-color);
 	--scrollbar-auto-scrollbar-color-track: transparent;
 	--channeltextarea-background: var(--accent-color);
-	--channeltextarea-background-hover: var(--background-2);
+	--channeltextarea-background-hover: var(--background-tertiary);
 	--avatar-roundess: 5px;
 }
 
@@ -68,6 +67,6 @@ ${cacheDir}/landing/discord.css|${scrDir}/wallbashdiscord.sh
 	--background-secondary: var(--background-tertiary);
 	--background-secondary-alt: var(--background-tertiary);
 	--background-floating: var(--background-2);
-	--background-mentioned: #<wallbash_2xa3> !important;
-	--background-mentioned-hover: #<wallbash_2xa4> !important;	
+	--background-mentioned: var(--accent-color);
+	--background-mentioned-hover: var(--scrollbar-auto-thumb);	
 }

--- a/Configs/.config/hyde/wallbash/Wall-Ways/discord.dcol
+++ b/Configs/.config/hyde/wallbash/Wall-Ways/discord.dcol
@@ -2,7 +2,7 @@ ${cacheDir}/landing/discord.css|${scrDir}/wallbashdiscord.sh
 
 :root {
 	--accent-color: #<wallbash_1xa1>;
-	--border-color: #<wallbash_pry3>;
+	--border-color: #<wallbash_1xa3>;
 	--background-1: #<wallbash_pry1>;
 	--background-2: #<wallbash_1xa2>;
 	--background-tertiary: #<wallbash_pry1>66;
@@ -12,7 +12,7 @@ ${cacheDir}/landing/discord.css|${scrDir}/wallbashdiscord.sh
 	--background-modifier-active: #<wallbash_4xa4> !important;
 	--text-normal: #<wallbash_txt1> !important;
 	--text-positive: #<wallbash_2xa9> !important;
-	--text-muted: #<wallbash_3xa9> !important;
+	--text-muted: #<wallbash_1xa9>66 !important;
 	--text-link: #<wallbash_4xa9> !important;
 	--button-background: #<wallbash_pry1> !important;
 	--button-background-hover: #<wallbash_pry1> !important;
@@ -39,7 +39,8 @@ ${cacheDir}/landing/discord.css|${scrDir}/wallbashdiscord.sh
 	--interactive-selected: var(--background-primary);
 	--interactive-active: var(--text-normal);
 	--interactive-normal: var(--text-normal);
-	--channels-default: var(--text-muted);
+  --interactive-muted: var(--text-muted);
+	--channels-default: var(--text-normal);
 	--header-primary: var(--text-normal);
 	--header-secondary: var(--text-muted);
 	--control-brand-foreground: var(--accent-color);


### PR DESCRIPTION
# Pull Request

## Description

This is an attempt to improve the discord theme. Now there are shades of the background color so it results into more beautiful theme. Also no more invisible text as mentioned in this issue (#1407). 

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

### Before: 
![image](https://github.com/prasanthrangan/hyprdots/assets/65595804/d8c7ffd9-7107-40dc-b2c0-8803ce9dbca2)

### After 
![image](https://github.com/prasanthrangan/hyprdots/assets/65595804/88021012-d75b-4bcb-b992-729c2c0328e5)

## Additional context

Add any other context about the problem here.
