### PR TITLE
feat: add support for 'Dracut'

### DIFF
--- a/Scripts/.extra/install_mod.sh
+++ b/Scripts/.extra/install_mod.sh
@@ -4,12 +4,33 @@
 #|-/ /--| Prasanth Rangan                               |-/ /--|#
 #|/ /---+-----------------------------------------------+/ /---|#
 
+#
+#? add nvidia variables to 'modprobe'
+#
+modprobe_opts() {
+  if [ $(grep 'options nvidia-drm modeset=1' /etc/modprobe.d/nvidia.conf | wc -l) -eq 0 ]; then
+    echo 'options nvidia-drm modeset=1' | sudo tee -a /etc/modprobe.d/nvidia.conf
+  fi
+}
+
+#
+#? check what program generates the 'initramfs'
+# mkinitcpio: in case of vanilla Arch & other distributions using it
+# dracut    : in case of EndeavourOS & other distributions using it
+#
 if [ $(lspci -k | grep -A 2 -E "(VGA|3D)" | grep -i nvidia | wc -l) -gt 0 ]; then
-    if [ $(grep 'MODULES=' /etc/mkinitcpio.conf | grep nvidia | wc -l) -eq 0 ]; then
-        sudo sed -i "/MODULES=/ s/)$/ nvidia nvidia_modeset nvidia_uvm nvidia_drm)/" /etc/mkinitcpio.conf
-        sudo mkinitcpio -P
-        if [ $(grep 'options nvidia-drm modeset=1' /etc/modprobe.d/nvidia.conf | wc -l) -eq 0 ]; then
-            echo 'options nvidia-drm modeset=1' | sudo tee -a /etc/modprobe.d/nvidia.conf
-        fi
+  if [ $(grep 'MODULES=' /etc/mkinitcpio.conf | grep nvidia | wc -l) -eq 0 ]; then
+    if [ -x "$(command -v dracut)" ]; then
+      if [ ! -f /etc/dracut.conf.d/nvidia.conf ]; then
+        # WARN: spaces after & before the douple quotations are important & left intensionally
+        echo 'force_drivers+=" nvidia nvidia_modeset nvidia_uvm nvidia_drm "' | sudo tee -a /etc/dracut.conf.d/nvidia.conf
+        sudo dracut-rebuild
+        modprobe_opts
+      fi
+    else
+      sudo sed -i "/MODULES=/ s/)$/ nvidia nvidia_modeset nvidia_uvm nvidia_drm)/" /etc/mkinitcpio.conf
+      sudo mkinitcpio -P
+      modprobe_opts
     fi
+  fi
 fi


### PR DESCRIPTION
# Pull Request

## Description

EndeavourOS & some other Linux distibutions using 'Dracut' as the 'initramfs image' generator inested of 'mkinitcpio', this commit should handle the case of using either (mkinitcpio OR dracut)

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected on (Vanilla Arch & EndeavourOS)
- [ ] All new and existing tests passed.

## Screenshots

N/A

## Additional context

N/A
