### PR TITLE
Update wallbashdiscord.sh

### DIFF
--- a/Configs/.local/share/bin/wallbashdiscord.sh
+++ b/Configs/.local/share/bin/wallbashdiscord.sh
@@ -22,13 +22,8 @@ client_list+=("$HOME/.var/app/xyz.armcord.ArmCord/config/ArmCord/themes/theme.cs
 
 for client_css in "${client_list[@]}" ; do
     eval client_css="${client_css}"
-    if [[ ! -d $(dirname "${client_css}") ]] ; then
-        continue
-    fi
-    if [[ "${enableWallDcol}" -gt 0 ]] ; then
+    if [[  -d $(dirname "${client_css}") ]] ; then
         cp "${discord_col}" "${client_css}"
-    else
-        > "${client_css}"
     fi
 done
 


### PR DESCRIPTION
# Pull Request

## Description


Enables Discord and derivatives Theme for disabled wallbash/mode Theme. Likely Buttons that are only have a border, for example "deactivate account" and "remove authentication-app" will have an invisible text or like "Edit User Profile", "Change Password", "View Backup Codes", "Enable SMS Authentication" and "Register a Security Key" in "Graphite Mono" Theme are some of the invisible buttons. All of those buttons have a blue background and white text and are unchanged as it seems.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that would cause existing functionality to not work as expected) kinda

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] My change requires a change to the documentation.
- [x] I have tested my code locally and it works as expected(the named problems occur)