### PR TITLE
fix : swww fails when the hyprctl cursor do not give correct value, This PR will handle it using 0,0 as fallback

### DIFF
--- a/Configs/.local/share/bin/swwwallpaper.sh
+++ b/Configs/.local/share/bin/swwwallpaper.sh
@@ -111,5 +111,5 @@ fi
 #// apply wallpaper
 
 echo ":: applying wall :: \"$(readlink -f "${wallSet}")\""
-swww img "$(readlink "${wallSet}")" --transition-bezier .43,1.19,1,.4 --transition-type "${xtrans}" --transition-duration "${wallTransDuration}" --transition-fps "${wallFramerate}" --invert-y --transition-pos "$(hyprctl cursorpos)" &
+swww img "$(readlink "${wallSet}")" --transition-bezier .43,1.19,1,.4 --transition-type "${xtrans}" --transition-duration "${wallTransDuration}" --transition-fps "${wallFramerate}" --invert-y --transition-pos "$(hyprctl cursorpos | grep -E '^[0-9]' || echo "0,0")" &
 


### PR DESCRIPTION
# Pull Request

Desc:

*    recently learned that `  hyprctl cursorpos `  cannot detect the position during theme change
*    During theme switching we tend to change cursors instantly,around 2-3 times
*    This sometimes causes hiccup to the system
*    Also causes ` hyprctl cursorpos`  to output ` Couldn't read (5) `
*    This PR handles that situation and defaults the cursorpos to "0,0"

Fixes:

   * Failing wallpaper change on themeswitch
