### PR TITLE
fixed master layout after updating hyprland to version v0.41.2

### DIFF
--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -102,7 +102,7 @@ dwindle {
 # See https://wiki.hyprland.org/Configuring/Master-Layout/
 
 master {
-    new_is_master = true
+    new_status = master
 }
 
 


### PR DESCRIPTION
`Config error in file /home/<user>/.config/hypr/hyprland.conf at line 105: config option < master:new_is_master > does not exist`

# Pull Request



## Description

After updating to the latest version of hyprland, specifically v.041.2, built from branch  at commit 918d8340afd652b011b937d29d5eea0be08467f5 the option master: new_is_master used before does not longer exist. My fixed is done looking at the hyprland website under 

https://wiki.hyprland.org/Configuring/Master-Layout/

It is the fourth option listed under the category name "master"



## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)



## Checklist

- [X] My code follows the code style of this project.

- [X] I have tested my code locally and it works as expected.