### PR TITLE
Fix the not themed pause button

### DIFF
--- a/Configs/.config/waybar/modules/mpris.jsonc
+++ b/Configs/.config/waybar/modules/mpris.jsonc
@@ -7,7 +7,7 @@
             "mpv": "🎵"
         },
         "status-icons": {
-            "paused": "⏸"
+            "paused": ""
         },
         // "ignored-players": ["firefox"]
         "max-length": 1000,


### PR DESCRIPTION
# Pull Request

## Description

I fixed the not themed pause button from the mpris module from waybar. 
Before:
![image](https://github.com/prasanthrangan/hyprdots/assets/79202140/ec6b906e-f60f-4e01-a065-d646cba9e820)
After:
![image](https://github.com/prasanthrangan/hyprdots/assets/79202140/17a0bf68-5fc3-4ba8-98fd-b694d52a9e56)


## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Additional context

This is my first pull request 🥵
