### PR TITLE
fix restore_cfg.sh not working with directories

### DIFF
--- a/Scripts/restore_cfg.sh
+++ b/Scripts/restore_cfg.sh
@@ -63,7 +63,7 @@ cat "${CfgLst}" | while read lst; do
             mkdir -p "${pth}"
         fi
 
-        if [ ! -f "${pth}/${cfg_chk}" ]; then
+        if [ ! -f "${pth}/${cfg_chk}" ] && [ ! -d "${pth}/${cfg_chk}" ]; then
             cp -r "${CfgDir}${tgt}/${cfg_chk}" "${pth}"
             echo -e "\033[0;32m[restore]\033[0m ${pth} <-- ${CfgDir}${tgt}/${cfg_chk}..."
         elif [ "${ovrWrte}" == "Y" ]; then


### PR DESCRIPTION
# Pull Request

## Description

I have fixed `restore_cfg.sh` to work with directories. Previously it would restore the configs if the overwrite option was set to no. I added a small piece of code to check that the config is not also a directory.

This PR is linked to my previously made issue: #1658 

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots
### Previously
`N|Y|${HOME}|.floorp|floorp-bin` 
![image](https://github.com/prasanthrangan/hyprdots/assets/79202140/ab628134-bbcd-488a-935f-23090444b11d)
### Now
`N|Y|${HOME}|.floorp|floorp-bin` 
![image](https://github.com/prasanthrangan/hyprdots/assets/79202140/cb06f967-a7c4-45fa-8587-a655043d5124)




