### PR TITLE
feat: opaque windows in gamemode

### DIFF
--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -37,6 +37,7 @@ exec-once = dunst # start notification demon
 exec-once = wl-paste --type text --watch cliphist store # clipboard store text data
 exec-once = wl-paste --type image --watch cliphist store # clipboard store image data
 exec-once = $scrPath/swwwallpaper.sh # start wallpaper daemon
+exec-once = $scrPath/swwwallselect.sh random # select a random wallpaper
 exec-once = $scrPath/batterynotify.sh # battery notification
 
 

--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -135,5 +135,6 @@ source = ~/.config/hypr/themes/theme.conf # theme specific settings
 source = ~/.config/hypr/themes/colors.conf # wallbash color override
 source = ~/.config/hypr/monitors.conf # initially empty, to be configured by user and remains static
 source = ~/.config/hypr/userprefs.conf # initially empty, to be configured by user and remains static
+source = ~/.config/hypr/opaque.conf
 
 # Note: as userprefs.conf is sourced at the end, settings configured in this file will override the defaults

--- a/Configs/.local/share/bin/gamemode.sh
+++ b/Configs/.local/share/bin/gamemode.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env sh
 HYPRGAMEMODE=$(hyprctl getoption animations:enabled | sed -n '1p' | awk '{print $2}')
 
+
+if [ $HYPRGAMEMODE = 1 ]; then
+  echo 'windowrulev2 = opacity 1.00 1.00,class:^(.*)$' > "$HOME/.config/hypr/opaque.conf"
+  # Sleep needed since this change will automatically reload hyprland
+	sleep 1
+fi
+
 # Waybar performance
 FILE="$HOME/.config/waybar/style.css"
 
@@ -25,5 +32,6 @@ if [ $HYPRGAMEMODE = 1 ]; then
         keyword decoration:rounding 0"
 	exit
 else
+	echo "" > "$HOME/.config/hypr/opaque.conf"
 	hyprctl reload
 fi

--- a/Configs/.local/share/bin/swwwallselect.sh
+++ b/Configs/.local/share/bin/swwwallselect.sh
@@ -35,6 +35,16 @@ r_override="window{width:100%;} listview{columns:${col_count};spacing:5em;} elem
 currentWall="$(basename "$(readlink "${hydeThemeDir}/wall.set")")"
 wallPathArray=("${hydeThemeDir}")
 wallPathArray+=("${wallAddCustomPath[@]}")
+
+#// if the user want a random wallpaper, don't display the rofi menu
+if [ "$1" = "random" ] ; then
+    randomWall=$(find "${wallPathArray}" -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \) | shuf -n 1)
+    rofiSel=$(basename "$randomWall")
+    "${ScrDir}/swwwallpaper.sh" -s "${wallPath}/${rofiSel}"
+    notify-send -a "t1" -i "${thmbDir}/$(set_hash "${setWall}").sqre" " ${rofiSel}"
+    exit
+fi
+
 get_hashmap "${wallPathArray[@]}"
 rofiSel=$(parallel --link echo -en "\$(basename "{1}")"'\\x00icon\\x1f'"${thmbDir}"'/'"{2}"'.sqre\\n' ::: "${wallList[@]}" ::: "${wallHash[@]}" | rofi -dmenu -theme-str "${r_scale}" -theme-str "${r_override}" -config "${rofiConf}" -select "${currentWall}")
 


### PR DESCRIPTION
# Pull Request

## Description

This make all windows opaque in gamemode. Since the blur is disabled but not the opacity, most of the windows, especially terminals, become unreadable. This will also improve power consumption

Please read these instructions and remove unnecessary text.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have added necessary comments/documentation to my code.
- [x] I have tested my code locally and it works as expected.
