### PR TITLE
feat: Accepts Hyprland Variable for gtk Theme and Icon

### DIFF
--- a/Configs/.local/share/bin/themeswitch.sh
+++ b/Configs/.local/share/bin/themeswitch.sh
@@ -70,9 +70,14 @@ source "${scrDir}/globalcontrol.sh"
 #// hypr
 
 sed '1d' "${hydeThemeDir}/hypr.theme" > "${confDir}/hypr/themes/theme.conf"
-gtkTheme="$(grep 'gsettings set org.gnome.desktop.interface gtk-theme' "${hydeThemeDir}/hypr.theme" | awk -F "'" '{print $((NF - 1))}')"
-gtkIcon="$(grep 'gsettings set org.gnome.desktop.interface icon-theme' "${hydeThemeDir}/hypr.theme" | awk -F "'" '{print $((NF - 1))}')"
-
+gtkTheme="$(
+{ grep -q "^[[:space:]]*\$GTK-THEME\s*=" "${hydeThemeDir}/hypr.theme" && grep "^[[:space:]]*\$GTK-THEME\s*=" "${hydeThemeDir}/hypr.theme" | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' ;} || 
+grep 'gsettings set org.gnome.desktop.interface gtk-theme' "${hydeThemeDir}/hypr.theme" | awk -F "'" '{print $((NF - 1))}'
+)"
+gtkIcon="$(
+{ grep -q "^[[:space:]]*\$ICON-THEME\s*=" "${hydeThemeDir}/hypr.theme" && grep "^[[:space:]]*\$ICON-THEME\s*=" "${hydeThemeDir}/hypr.theme" | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' ;} ||  
+grep 'gsettings set org.gnome.desktop.interface icon-theme' "${hydeThemeDir}/hypr.theme" | awk -F "'" '{print $((NF - 1))}'
+)"
 
 #// qtct
 


### PR DESCRIPTION
# Pull Request

To support ` Hyde theme patch` to use variable $GTK-THEME and $ICON-THEM  
https://discord.com/channels/1200448076620501063/1260669168496279582


This way it is easier to set gtk theme and icon theme using hyprland variable than using the gsettings command. 
 -Should still support the older format if the $Variable do not exist 
 