### PR TITLE
feat: respect the color scheme set in hypr.theme when in theme mode.

### DIFF
--- a/Configs/.local/share/bin/swwwallbash.sh
+++ b/Configs/.local/share/bin/swwwallbash.sh
@@ -237,7 +237,9 @@ if [ "${enableWallDcol}" -eq 0 ] && [[ "${reload_flag}" -eq 1 ]] ; then
     done < <(find "${wallbashDir}/Wall-Dcol" -type f -name "*.dcol")
 
     parallel fn_wallbash ::: "${deployList[@]}"
-
+    colorScheme="$({ grep -q "^[[:space:]]*\$COLOR-SCHEME\s*=" "${hydeThemeDir}/hypr.theme" && grep "^[[:space:]]*\$COLOR-SCHEME\s*=" "${hydeThemeDir}/hypr.theme" | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' ;} || 
+                    grep 'gsettings set org.gnome.desktop.interface color-scheme' "${hydeThemeDir}/hypr.theme" | awk -F "'" '{print $((NF - 1))}')"
+    { grep -q "${dcol_mode}" <<< "${colorScheme}" && enableWallDcol=3 ;} || { enableWallDcol=2 && echo  "colors :: ${dcol_mode} => ${dcol_invt}" ;}
 elif [ "${enableWallDcol}" -gt 0 ] ; then
 
     echo ":: deploying wallbash colors :: ${dcol_mode} wallpaper detected"

--- a/Configs/.local/share/bin/swwwallbash.sh
+++ b/Configs/.local/share/bin/swwwallbash.sh
@@ -237,18 +237,21 @@ if [ "${enableWallDcol}" -eq 0 ] && [[ "${reload_flag}" -eq 1 ]] ; then
     done < <(find "${wallbashDir}/Wall-Dcol" -type f -name "*.dcol")
 
     parallel fn_wallbash ::: "${deployList[@]}"
-    # detects the color-scheme set in hypr.theme and falls back if nothing is parsed.
+elif [ "${enableWallDcol}" -gt 0 ] ; then
+
+    echo ":: deploying wallbash colors :: ${dcol_mode} wallpaper detected"
+    find "${wallbashDir}/Wall-Dcol" -type f -name "*.dcol" | parallel fn_wallbash {}
+
+fi
+
+#  Theme mode: detects the color-scheme set in hypr.theme and falls back if nothing is parsed.
+if [ "${enableWallDcol}" -eq 0 ]; then
     colorScheme="$({ grep -q "^[[:space:]]*\$COLOR-SCHEME\s*=" "${hydeThemeDir}/hypr.theme" && grep "^[[:space:]]*\$COLOR-SCHEME\s*=" "${hydeThemeDir}/hypr.theme" | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' ;} || 
                     grep 'gsettings set org.gnome.desktop.interface color-scheme' "${hydeThemeDir}/hypr.theme" | awk -F "'" '{print $((NF - 1))}')"
     colorScheme=${colorScheme:-$(gsettings get org.gnome.desktop.interface color-scheme)} 
     # should be declared explicitly so we can easily debug
     grep -q "dark" <<< "${colorScheme}" && enableWallDcol=2
     grep -q "light" <<< "${colorScheme}" && enableWallDcol=3 
-elif [ "${enableWallDcol}" -gt 0 ] ; then
-
-    echo ":: deploying wallbash colors :: ${dcol_mode} wallpaper detected"
-    find "${wallbashDir}/Wall-Dcol" -type f -name "*.dcol" | parallel fn_wallbash {}
-
 fi
 
 find "${wallbashDir}/Wall-Ways" -type f -name "*.dcol" | parallel fn_wallbash {}

--- a/Configs/.local/share/bin/swwwallbash.sh
+++ b/Configs/.local/share/bin/swwwallbash.sh
@@ -239,7 +239,9 @@ if [ "${enableWallDcol}" -eq 0 ] && [[ "${reload_flag}" -eq 1 ]] ; then
     parallel fn_wallbash ::: "${deployList[@]}"
     colorScheme="$({ grep -q "^[[:space:]]*\$COLOR-SCHEME\s*=" "${hydeThemeDir}/hypr.theme" && grep "^[[:space:]]*\$COLOR-SCHEME\s*=" "${hydeThemeDir}/hypr.theme" | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' ;} || 
                     grep 'gsettings set org.gnome.desktop.interface color-scheme' "${hydeThemeDir}/hypr.theme" | awk -F "'" '{print $((NF - 1))}')"
-    { grep -q "${dcol_mode}" <<< "${colorScheme}" && enableWallDcol=3 ;} || { enableWallDcol=2 && echo  "colors :: ${dcol_mode} => ${dcol_invt}" ;}
+    # Should be declared explicitly so we can easily debug
+    grep -q "dark" <<< "${colorScheme}" && enableWallDcol=2
+    grep -q "light" <<< "${colorScheme}" && enableWallDcol=3 
 elif [ "${enableWallDcol}" -gt 0 ] ; then
 
     echo ":: deploying wallbash colors :: ${dcol_mode} wallpaper detected"

--- a/Configs/.local/share/bin/swwwallbash.sh
+++ b/Configs/.local/share/bin/swwwallbash.sh
@@ -237,9 +237,11 @@ if [ "${enableWallDcol}" -eq 0 ] && [[ "${reload_flag}" -eq 1 ]] ; then
     done < <(find "${wallbashDir}/Wall-Dcol" -type f -name "*.dcol")
 
     parallel fn_wallbash ::: "${deployList[@]}"
+    # detects the color-scheme set in hypr.theme and falls back if nothing is parsed.
     colorScheme="$({ grep -q "^[[:space:]]*\$COLOR-SCHEME\s*=" "${hydeThemeDir}/hypr.theme" && grep "^[[:space:]]*\$COLOR-SCHEME\s*=" "${hydeThemeDir}/hypr.theme" | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' ;} || 
                     grep 'gsettings set org.gnome.desktop.interface color-scheme' "${hydeThemeDir}/hypr.theme" | awk -F "'" '{print $((NF - 1))}')"
-    # Should be declared explicitly so we can easily debug
+    colorScheme=${colorScheme:-$(gsettings get org.gnome.desktop.interface color-scheme)} 
+    # should be declared explicitly so we can easily debug
     grep -q "dark" <<< "${colorScheme}" && enableWallDcol=2
     grep -q "light" <<< "${colorScheme}" && enableWallDcol=3 
 elif [ "${enableWallDcol}" -gt 0 ] ; then


### PR DESCRIPTION
wallbash for Wall-Ways should respect the theme's preferred color-scheme.  (following the hypr.theme)

* Should only be activated when wallbash is set to 0 or theme mode
* if 'prefer-light' then Wall-Ways *.dcol should be in light mode. If dcol_mode is dark it should be inverted to light
* options can either a or b : 
    a.  elif "prefer-dark" they should be in dark mode. If it is in light invert to dark (if not declared then skip) 
    b. else they should be in dark mode. If it is in light invert to dark (dark-mode by default)

This way we can have consistent color-scheme including the persistent wallbash inside ./Wall-Ways (always wallabsh mode) 

*** Just found about it recently when I disable wallbash and some apps are in light mode even if prefer-dark is set.

also might close #1677 