### PR TITLE
Resolves #1695. Improve rofi's error message style

### DIFF
--- a/Configs/.config/rofi/styles/style_1.rasi
+++ b/Configs/.config/rofi/styles/style_1.rasi
@@ -138,3 +138,17 @@ element-text {
     text-color:                  inherit;
 }
 
+// Error message //
+error-message {
+    text-color:                  @main-fg;
+    background-color:            @main-bg;
+    text-transform:              capitalize;
+    children:                    [ "textbox" ];
+}
+
+textbox {
+    text-color:                  inherit;
+    background-color:            inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.5;
+}

--- a/Configs/.config/rofi/styles/style_10.rasi
+++ b/Configs/.config/rofi/styles/style_10.rasi
@@ -119,3 +119,17 @@ element-text {
     text-color:                  inherit;
 }
 
+// Error message //
+error-message {
+    text-color:                  @main-fg;
+    background-color:            @main-bg;
+    text-transform:              capitalize;
+    children:                    [ "textbox" ];
+}
+
+textbox {
+    text-color:                  inherit;
+    background-color:            inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.5;
+}

--- a/Configs/.config/rofi/styles/style_11.rasi
+++ b/Configs/.config/rofi/styles/style_11.rasi
@@ -113,3 +113,17 @@ element-text {
     text-color:                  inherit;
 }
 
+// Error message //
+error-message {
+    text-color:                  @main-fg;
+    background-color:            @main-bg;
+    text-transform:              capitalize;
+    children:                    [ "textbox" ];
+}
+
+textbox {
+    text-color:                  inherit;
+    background-color:            inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.5;
+}

--- a/Configs/.config/rofi/styles/style_12.rasi
+++ b/Configs/.config/rofi/styles/style_12.rasi
@@ -114,3 +114,17 @@ element-text {
     text-color:                  inherit;
 }
 
+// Error message //
+error-message {
+    text-color:                  @main-fg;
+    background-color:            @main-bg;
+    text-transform:              capitalize;
+    children:                    [ "textbox" ];
+}
+
+textbox {
+    text-color:                  inherit;
+    background-color:            inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.5;
+}

--- a/Configs/.config/rofi/styles/style_2.rasi
+++ b/Configs/.config/rofi/styles/style_2.rasi
@@ -133,3 +133,17 @@ element-text {
     text-color:                  inherit;
 }
 
+// Error message //
+error-message {
+    text-color:                  @main-fg;
+    background-color:            @main-bg;
+    text-transform:              capitalize;
+    children:                    [ "textbox" ];
+}
+
+textbox {
+    text-color:                  inherit;
+    background-color:            inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.5;
+}

--- a/Configs/.config/rofi/styles/style_3.rasi
+++ b/Configs/.config/rofi/styles/style_3.rasi
@@ -133,3 +133,17 @@ element-text {
     text-color:                  inherit;
 }
 
+// Error message //
+error-message {
+    text-color:                  @main-fg;
+    background-color:            @main-bg;
+    text-transform:              capitalize;
+    children:                    [ "textbox" ];
+}
+
+textbox {
+    text-color:                  inherit;
+    background-color:            inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.5;
+}

--- a/Configs/.config/rofi/styles/style_4.rasi
+++ b/Configs/.config/rofi/styles/style_4.rasi
@@ -131,3 +131,17 @@ element-text {
     text-color:                  inherit;
 }
 
+// Error message //
+error-message {
+    text-color:                  @main-fg;
+    background-color:            @main-bg;
+    text-transform:              capitalize;
+    children:                    [ "textbox" ];
+}
+
+textbox {
+    text-color:                  inherit;
+    background-color:            inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.5;
+}

--- a/Configs/.config/rofi/styles/style_5.rasi
+++ b/Configs/.config/rofi/styles/style_5.rasi
@@ -125,3 +125,17 @@ element-text {
     text-color:                  inherit;
 }
 
+// Error message //
+error-message {
+    text-color:                  @main-fg;
+    background-color:            @main-bg;
+    text-transform:              capitalize;
+    children:                    [ "textbox" ];
+}
+
+textbox {
+    text-color:                  inherit;
+    background-color:            inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.5;
+}

--- a/Configs/.config/rofi/styles/style_6.rasi
+++ b/Configs/.config/rofi/styles/style_6.rasi
@@ -130,3 +130,17 @@ element-text {
     text-color:                  inherit;
 }
 
+// Error message //
+error-message {
+    text-color:                  @main-fg;
+    background-color:            @main-bg;
+    text-transform:              capitalize;
+    children:                    [ "textbox" ];
+}
+
+textbox {
+    text-color:                  inherit;
+    background-color:            inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.5;
+}

--- a/Configs/.config/rofi/styles/style_7.rasi
+++ b/Configs/.config/rofi/styles/style_7.rasi
@@ -142,3 +142,17 @@ element-text {
     text-color:                  inherit;
 }
 
+// Error message //
+error-message {
+    text-color:                  @main-fg;
+    background-color:            @main-bg;
+    text-transform:              capitalize;
+    children:                    [ "textbox" ];
+}
+
+textbox {
+    text-color:                  inherit;
+    background-color:            inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.5;
+}

--- a/Configs/.config/rofi/styles/style_8.rasi
+++ b/Configs/.config/rofi/styles/style_8.rasi
@@ -135,3 +135,17 @@ element-text {
     text-color:                  inherit;
 }
 
+// Error message //
+error-message {
+    text-color:                  @main-fg;
+    background-color:            @main-bg;
+    text-transform:              capitalize;
+    children:                    [ "textbox" ];
+}
+
+textbox {
+    text-color:                  inherit;
+    background-color:            inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.5;
+}

--- a/Configs/.config/rofi/styles/style_9.rasi
+++ b/Configs/.config/rofi/styles/style_9.rasi
@@ -111,3 +111,17 @@ element-text {
     text-color:                  inherit;
 }
 
+// Error message //
+error-message {
+    text-color:                  @main-fg;
+    background-color:            @main-bg;
+    text-transform:              capitalize;
+    children:                    [ "textbox" ];
+}
+
+textbox {
+    text-color:                  inherit;
+    background-color:            inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.5;
+}


### PR DESCRIPTION
# Pull Request

## Description
When trying to open an application in rofi that doesn't exist an unstyled error message with white background is shown.

I added the following code to hyprdots rofi styles in order to center the text and inherit the theme colors.

```rasi
// Error message //
error-message {
    text-color:                  @main-fg;
    background-color:            @main-bg;
    text-transform:              capitalize;
    children:                    [ "textbox" ];
}

textbox {
    text-color:                  inherit;
    background-color:            inherit;
    vertical-align:              0.5;
    horizontal-align:            0.5;
}
``` 
Fixes #1695

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

![image](https://github.com/user-attachments/assets/cec69e68-82b7-49a9-8936-f53dbc5db2ac)