### PR TITLE
Margin to menu items added

### DIFF
--- a/Configs/.config/hyde/wallbash/Wall-Dcol/kvantum/kvconfig.dcol
+++ b/Configs/.config/hyde/wallbash/Wall-Dcol/kvantum/kvconfig.dcol
@@ -385,6 +385,10 @@ interior.element=menuitem
 indicator.size=8
 text.focus.color=#<wallbash_1xa9>
 text.press.color=#<wallbash_1xa9>
+text.margin.top=2
+text.margin.bottom=2
+text.margin.left=15
+text.margin.right=5
 
 [MenuBarItem]
 inherits=PanelButtonCommand


### PR DESCRIPTION
# Pull Request

## Description
This is a little modification to improve the interface on menu items from Dolphin.

## Type of change

Please put an `x` in the boxes that apply:

- [x ] **Other** (provide details below)

The addition of 4 properties for text margin in the wallbash kvantum theme file.

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.

## Screenshot
### Before
![240726_14h39m15s_screenshot](https://github.com/user-attachments/assets/46c14124-799c-40b8-95ba-8152add8aaaf)
### After
![240726_14h39m54s_screenshot](https://github.com/user-attachments/assets/ea15fd9d-913c-46b3-b22c-123a45758240)
