### PR TITLE
Feature: Disable KDE baloo file indexing

### DIFF
--- a/Configs/.config/baloofilerc
+++ b/Configs/.config/baloofilerc
@@ -1,0 +1,2 @@
+[Basic Settings]
+Indexing-Enabled=false

--- a/Scripts/restore_cfg.lst
+++ b/Scripts/restore_cfg.lst
@@ -26,7 +26,7 @@ Y|Y|${HOME}/.config|wlogout|wlogout
 Y|Y|${HOME}/.config|xsettingsd nwg-look gtk-3.0|nwg-look
 Y|Y|${HOME}/.icons|default|nwg-look
 Y|Y|${HOME}|.gtkrc-2.0|nwg-look
-Y|Y|${HOME}/.config|dolphinrc kdeglobals|dolphin
+Y|Y|${HOME}/.config|dolphinrc kdeglobals baloofilerc|dolphin
 Y|Y|${HOME}/.config/menus|applications.menu|dolphin
 Y|Y|${HOME}/.local/share|dolphin|dolphin
 Y|Y|${HOME}/.local/share/kxmlgui5|dolphin|dolphin

--- a/Scripts/restore_cfg.lst
+++ b/Scripts/restore_cfg.lst
@@ -26,7 +26,8 @@ Y|Y|${HOME}/.config|wlogout|wlogout
 Y|Y|${HOME}/.config|xsettingsd nwg-look gtk-3.0|nwg-look
 Y|Y|${HOME}/.icons|default|nwg-look
 Y|Y|${HOME}|.gtkrc-2.0|nwg-look
-Y|Y|${HOME}/.config|dolphinrc kdeglobals baloofilerc|dolphin
+Y|Y|${HOME}/.config|dolphinrc kdeglobals|dolphin
+N|Y|${HOME}/.config|baloofilerc|dolphin
 Y|Y|${HOME}/.config/menus|applications.menu|dolphin
 Y|Y|${HOME}/.local/share|dolphin|dolphin
 Y|Y|${HOME}/.local/share/kxmlgui5|dolphin|dolphin


### PR DESCRIPTION
# Pull Request

## Description

`baloo` package in installed as dependency of dolphin and provides file indexing and search features, which does not work without plasma desktop:

### Before
```sh
$ balooctl6 status
Baloo Index could not be opened
```

### After
```sh
$ balooctl6 status
Baloo is currently disabled. To enable, please run balooctl enable
```

This PR add config for disabling file indexing, which result in one less process running. Not much, but why not.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.