### PR TITLE
fix: Fix deprecated no_hardware_cursors environment variable

### DIFF
--- a/Configs/.config/hypr/nvidia.conf
+++ b/Configs/.config/hypr/nvidia.conf
@@ -7,5 +7,8 @@
 env = LIBVA_DRIVER_NAME,nvidia
 env = __GLX_VENDOR_LIBRARY_NAME,nvidia
 env = __GL_VRR_ALLOWED,1
-env = WLR_NO_HARDWARE_CURSORS,1
 env = WLR_DRM_NO_ATOMIC,1
+
+cursor {
+    no_hardware_cursors = true
+}

--- a/Configs/.config/hypr/nvidia.conf
+++ b/Configs/.config/hypr/nvidia.conf
@@ -9,6 +9,4 @@ env = __GLX_VENDOR_LIBRARY_NAME,nvidia
 env = __GL_VRR_ALLOWED,1
 env = WLR_DRM_NO_ATOMIC,1
 
-cursor {
-    no_hardware_cursors = true
-}
+cursor:no_hardware_cursors = true


### PR DESCRIPTION
# Pull Request

## Description

According to https://wiki.hyprland.org/Nvidia/ the environment variable WLR_NO_HARDWARE_CURSORS is deprecated and we should use cursor:no_hardware_cursors instead.

Without this change, the mouse lags and CPU spikes like crazy, from personal experience and from (https://github.com/prasanthrangan/hyprdots/issues/1739)

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.