### PR TITLE
Added a script to start the startup programs like other DE

### DIFF
--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -38,7 +38,7 @@ exec-once = wl-paste --type text --watch cliphist store # clipboard store text d
 exec-once = wl-paste --type image --watch cliphist store # clipboard store image data
 exec-once = $scrPath/swwwallpaper.sh # start wallpaper daemon
 exec-once = $scrPath/batterynotify.sh # battery notification
-
+exec-once = $scrPath/autostart.sh # run the startups
 
 # █▀▀ █▄░█ █░█
 # ██▄ █░▀█ ▀▄▀

--- a/Configs/.local/share/bin/autostart.sh
+++ b/Configs/.local/share/bin/autostart.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Directory containing the .desktop files
+AUTOSTART_DIR="$HOME/.config/autostart/"
+for desktop_file in "$AUTOSTART_DIR"*.desktop; do
+  if [ -f "$desktop_file" ]; then
+    exec_command=$(grep -E '^Exec=' "$desktop_file" | sed 's/^Exec=//')
+    if [ -n "$exec_command" ]; then
+      $exec_command &
+    fi
+  fi
+done


### PR DESCRIPTION
# Pull Request

## Description

This PR adds a bash script that automatically runs executable commands from `.desktop` files located in the `~/.config/autostart/` directory. This feature mimics the startup program behavior seen in other Desktop Environments (DE).

## Type of change

Please put an `x` in the boxes that apply:

- [x] **New feature** (non-breaking change which adds functionality)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.