### PR TITLE
Fix Typo in Alias Command Description

### DIFF
--- a/Configs/.zshrc
+++ b/Configs/.zshrc
@@ -67,7 +67,7 @@ alias lt='eza --icons=auto --tree' # list folder as tree
 alias un='$aurhelper -Rns' # uninstall package
 alias up='$aurhelper -Syu' # update system/package/aur
 alias pl='$aurhelper -Qs' # list installed package
-alias pa='$aurhelper -Ss' # list availabe package
+alias pa='$aurhelper -Ss' # list available package
 alias pc='$aurhelper -Sc' # remove unused cache
 alias po='$aurhelper -Qtdq | $aurhelper -Rns -' # remove unused packages, also try > $aurhelper -Qqd | $aurhelper -Rsu --print -
 alias vc='code' # gui code editor


### PR DESCRIPTION
**Title:** Fix Typo in Alias Command Description

**Description:**

This pull request addresses a minor typographical error in the alias command comments. Specifically, it corrects the typo in the description for the `pa` alias command.

- **Issue Fixed:** Typo in comment description
- **Motivation:** Ensures clarity and accuracy in the alias command comments
- **Dependencies:** None
- **Related Issue:** N/A

**Type of change:**

- [x] **Bug fix** (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

**Additional context:**

This PR corrects the alias comment from `availabe package` to `available package`.