### PR TITLE
Feature: Change rofi package from `rofi-lbonn-wayland-git` to `rofi-wayland`

### DIFF
--- a/Scripts/custom_hypr.lst
+++ b/Scripts/custom_hypr.lst
@@ -25,7 +25,7 @@ qt5-graphicaleffects                                   # for sddm theme effects
 # --------------------------------------------------- // Window Manager
 hyprland                                               # wlroots-based wayland compositor
 dunst                                                  # notification daemon
-rofi-lbonn-wayland-git                                 # application launcher
+rofi-wayland                                           # application launcher
 waybar                                                 # system bar
 swww                                                   # wallpaper
 swaylock-effects-git                                   # lock screen


### PR DESCRIPTION
# Pull Request

## Description

`rofi-lbonn-wayland-git` aur package is not versioned properly and have frozen on version `1.7.5.wayland1.r42` which means if you want updated version, this package should be synced explicitly using `yay/paru -S rofi-lbonn-wayland-git`.

Recently in main arch repo [`rofi-wayland`](https://archlinux.org/packages/extra/x86_64/rofi-wayland/) package has appeared. It is versioned properly and has version `1.7.5+wayland3` which corresponds to [lbonn/rofi repo](https://github.com/lbonn/rofi/releases)

The only one reason of this PR is to provide feature to update `rofi` automatically using `<yay/paru> -Syu` without necessity to update package explicitly.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
