### PR TITLE
Enable numlock on startup

### DIFF
--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -72,6 +72,7 @@ input {
 
     sensitivity = 0
     force_no_accel = 1
+    numlock_by_default = true
 }
 
 # See https://wiki.hyprland.org/Configuring/Keywords/#executing


### PR DESCRIPTION
# Pull Request

## Description

This PR adds the ability to enable NumLock by default on startup in Hyperland. This change is essential because NumLock gets disabled whenever Hyde is updated, and having NumLock enabled by default is crucial for many users who rely on it.

### Code Changes:

In .config/hypr/hyprland.conf in the input configuration section, I've added the line:

```bash
numlock_by_default = true
```

This ensures that NumLock is enabled automatically when the system starts, providing a better user experience.

## Type of change

- [x] **New feature** (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.

## Additional context

I believe enabling NumLock by default is crucial for user convenience, especially since it tends to reset after updates. This change will help maintain a consistent experience.