### PR TITLE
Fix: drop actions not supported by waybar from clock module

### DIFF
--- a/Configs/.config/waybar/config.jsonc
+++ b/Configs/.config/waybar/config.jsonc
@@ -135,8 +135,6 @@
         },
         "actions": {
             "on-click-right": "mode",
-            "on-click-forward": "tz_up",
-            "on-click-backward": "tz_down",
             "on-scroll-up": "shift_up",
             "on-scroll-down": "shift_down"
         }

--- a/Configs/.config/waybar/modules/clock.jsonc
+++ b/Configs/.config/waybar/modules/clock.jsonc
@@ -16,8 +16,6 @@
         },
         "actions": {
             "on-click-right": "mode",
-            "on-click-forward": "tz_up",
-            "on-click-backward": "tz_down",
             "on-scroll-up": "shift_up",
             "on-scroll-down": "shift_down"
         }


### PR DESCRIPTION
# Pull Request

## Description

According to [waybar clock module documentation](https://github.com/Alexays/Waybar/wiki/Module:-Clock#calendar-in-chinese-alignment) there are two actions provided: `on-click-forward` and `on-click-backward`. 

But as we can see in [waybar source code](https://github.com/Alexays/Waybar/blob/88828265c016d1b32c41919ae0c3b6f3ed2f9dfb/include/AModule.hpp#L45-L60), there are no such actions. Actions binded to `on-click-forward` and `on-click-backward` are non-operational.

As I can see there is no issue opened for this, so I assume these actions are not used by anyone.

This PR removes non-operational actions to make config two rows smaller.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
