### PR TITLE
Use hyprland 0.43 capabilities for switching keyboard layout

### DIFF
--- a/Configs/.local/share/bin/keyboardswitch.sh
+++ b/Configs/.local/share/bin/keyboardswitch.sh
@@ -3,10 +3,7 @@
 scrDir=`dirname "$(realpath "$0")"`
 source $scrDir/globalcontrol.sh
 
-hyprctl devices -j | jq -r '.keyboards[].name' | while read keyName
-do
-    hyprctl switchxkblayout "$keyName" next
-done
+hyprctl switchxkblayout all next
 
 layMain=$(hyprctl -j devices | jq '.keyboards' | jq '.[] | select (.main == true)' | awk -F '"' '{if ($2=="active_keymap") print $4}')
 notify-send -a "t1" -r 91190 -t 800 -i "~/.config/dunst/icons/keyboard.svg" "${layMain}"


### PR DESCRIPTION
# Pull Request

## Description

In 0.43 was introduced new [`all` parameter for `hyprctl switchxkblayout` command](https://wiki.hyprland.org/Configuring/Using-hyprctl/#switchxkblayout).
> DEVICE can also be current or all, self-explanatory. Current is the main keyboard from devices.

Using this parameter simplifies `keyboardswitch.sh` script: no need to query all keyboards and loop them.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

