### PR TITLE
Add `-bin` packages options for AUR helpers

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -118,7 +118,7 @@ EOF
 
         case "${promptIn}" in
             1) export getAur="yay" ;;
-            2) export getAur="paru" ;;
+            2) export getAur="paru-bin" ;;
             *) echo -e "...Invalid option selected..." ; exit 1 ;;
         esac
     fi

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -119,8 +119,8 @@ EOF
         case "${promptIn}" in
             1) export getAur="yay" ;;
             2) export getAur="yay-bin" ;;
-            1) export getAur="paru" ;;
-            2) export getAur="paru-bin" ;;
+            3) export getAur="paru" ;;
+            4) export getAur="paru-bin" ;;
             *) echo -e "...Invalid option selected..." ; exit 1 ;;
         esac
     fi

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -114,7 +114,7 @@ EOF
     #----------------#
     if ! chk_list "aurhlpr" "${aurList[@]}"; then
         echo -e "Available aur helpers:\n[1] yay\n[2] yay (bin)\n[3] paru\n[4] paru (bin)"
-        prompt_timer 120 "Enter option number"
+        prompt_timer 120 "Enter option number [default: yay] "
 
         case "${promptIn}" in
             1) export getAur="yay" ;;

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -113,11 +113,13 @@ EOF
     # get user prefs #
     #----------------#
     if ! chk_list "aurhlpr" "${aurList[@]}"; then
-        echo -e "Available aur helpers:\n[1] yay\n[2] paru"
+        echo -e "Available aur helpers:\n[1] yay\n[2] yay (bin)\n[3] paru\n[4] paru (bin)"
         prompt_timer 120 "Enter option number"
 
         case "${promptIn}" in
             1) export getAur="yay" ;;
+            2) export getAur="yay-bin" ;;
+            1) export getAur="paru" ;;
             2) export getAur="paru-bin" ;;
             *) echo -e "...Invalid option selected..." ; exit 1 ;;
         esac


### PR DESCRIPTION
# Add pre-compiled binary packages options for AUR helpers

## Description

Added `yay-bin` and `paru-bin` installation choices.

~~`paru` has compilation issues sometimes, `paru-bin` is overall faster (precompiled binary) and using it has no real downsides.~~

## Type of change

- [x] **New feature**
- [x] **Other**

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.