### PR TITLE
improved waybar cava

### DIFF
--- a/Configs/.config/hyde/hyde.conf
+++ b/Configs/.config/hyde/hyde.conf
@@ -87,3 +87,31 @@ rofiScale=9
 #// available styles - 1 (default) , 2
 wlogoutStyle=1
 
+# waybar
+
+# // waybar_cava_bar - bar for waybar cava - default "▁▂▃▄▅▆▇█"
+# waybar_cava_bar="░▒▓█"
+# waybar_cava_bar="▖▗▘▙▚▛▜▝▞▟"
+# waybar_cava_bar="▂▃▄▅▆▇█"
+# waybar_cava_bar="▕▏▎▍▌▋▊▉"
+# waybar_cava_bar="⣀⣄⣤⣦⣶⣷⣿"
+# waybar_cava_bar="⠁⠂⠄⡀⢀⠠⠐⠈"
+# waybar_cava_bar="⠋⠙⠹⢸⣰⣤⣦⣶"
+# waybar_cava_bar="🌑🌒🌓🌔🌕🌖🌗🌘"
+# waybar_cava_bar="🌕🌖🌗🌘🌒🌓🌔🌕"
+# waybar_cava_bar="★☆★☆★☆★☆"
+# waybar_cava_bar="⣾⣽⣻⢿⡿⣟⣯⣷"
+# waybar_cava_bar="ᗧᗣᗤᗥᗦᗧᗣᗤᗥᗦ"
+
+# // waybar_cava_width - width for waybar cava - default 8
+# waybar_cava_width=10
+
+# // waybar_cava_range - range for waybar cava - default 7
+# waybar_cava_range=7
+
+# // waybar_cava_stbmode - standby mode for waybar cava - default 0
+# 0: clean - totally hides the module
+# 1: blank - makes module expand as spaces
+# 2: full - occupies the module with full bar
+# 3: low - makes the module display the lowest set bar
+# waybar_cava_stbmode=0

--- a/Configs/.config/waybar/modules/cava.jsonc
+++ b/Configs/.config/waybar/modules/cava.jsonc
@@ -1,4 +1,6 @@
 "custom/cava": {
+	"format": "{}",
 	"exec": "waybar_cava.sh",
-	"format": "{}"
+	"restart-interval": 1,
+	"hide-empty": true
 },

--- a/Configs/.local/share/bin/waybar_cava.sh
+++ b/Configs/.local/share/bin/waybar_cava.sh
@@ -1,35 +1,117 @@
 #!/bin/env bash
 #----- Optimized bars animation without much CPU usage increase --------
-bar="▁▂▃▄▅▆▇█"
+#----- Optimized bars animation without much CPU usage increase pt2 --------
+
+scrDir=$(dirname "$(realpath "$0")")
+# shellcheck source=/dev/null
+. "${scrDir}/globalcontrol.sh"
+usage() {
+    cat <<HELP
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+  --bar <waybar_cava_bar>  Specify the characters to use for the bar animation (default: ▁▂▃▄▅▆▇█).
+  --width <waybar_cava_width>     Specify the width of the bar.
+  --range <waybar_cava_range>     Specify the range of the bar.
+  --help                  Display this help message and exit.
+  --restart               Restart the waybar_cava.
+  --mode <waybar_cava_stbmode>   Specify the standby mode for waybar cava (default: 0).
+HELP
+    exit 1
+}
+
+# Parse command line arguments using getopt
+if ! ARGS=$(getopt -o "hr" -l "help,bar:,width:,range:,restart,mode:" -n "$0" -- "$@"); then
+    usage
+fi
+
+eval set -- "$ARGS"
+while true; do
+    case "$1" in
+    --help | -h)
+        usage
+        ;;
+    --bar)
+        waybar_cava_bar="$2"
+        shift 2
+        ;;
+    --width)
+        waybar_cava_width="$2"
+        shift 2
+        ;;
+    --range)
+        waybar_cava_range="$2"
+        shift 2
+        ;;
+    --restart) # restart the waybar_cava
+        pkill -f "cava -p /tmp/bar_cava_config"
+        exit 0
+        ;;
+    --mode)
+        waybar_cava_stbmode="$2"
+        shift 2
+        ;;
+    --)
+        shift
+        break
+        ;;
+    *)
+        usage
+        ;;
+    esac
+done
+
+bar="${waybar_cava_bar:-▁▂▃▄▅▆▇█}"
 dict="s/;//g"
 
 # Calculate the length of the bar outside the loop
 bar_length=${#bar}
+bar_width=${waybar_cava_width:-${bar_length}}
+bar_range=${waybar_cava_range:-$((bar_length - 1))}
 
+standby_mode=${waybar_cava_stbmode:-0} # 0:clean, 1:blank, 2:full,3:last
+if [ "${standby_mode}" -le 0 ]; then unset standby_bar; fi
 # Create dictionary to replace char with bar
-for ((i = 0; i < bar_length; i++)); do
-    dict+=";s/$i/${bar:$i:1}/g"
+i=0
+while [ $i -lt "${bar_length}" ] || [ $i -lt "${bar_width}" ]; do
+    if [ $i -lt "${bar_length}" ]; then
+        dict="$dict;s/$i/${bar:$i:1}/g"
+    fi
+    if [ $i -lt "${bar_width}" ] && [ "${standby_mode}" -gt 0 ]; then
+        if [ "${standby_mode}" -eq 2 ]; then
+            standby_bar="$standby_bar${bar:$i:1}"
+        elif [ "${standby_mode}" -eq 1 ]; then
+            standby_bar="$standby_bar "
+        fi
+    fi
+    ((i++))
 done
 
 # Create cava config
 config_file="/tmp/bar_cava_config"
 cat >"$config_file" <<EOF
 [general]
-bars = 10
+bars = ${bar_width}
+sleep_timer = 1
 
 [input]
 method = pulse
 source = auto
-
 [output]
 method = raw
 raw_target = /dev/stdout
 data_format = ascii
-ascii_max_range = 7
+ascii_max_range = ${bar_range}
 EOF
 
-# Kill cava if it's already running
-pkill -f "cava -p $config_file"
+listen_to_cava() {
+    echo ""
+    while IFS= read -r line; do
+        if grep -qE "^0;(0;)*$" <<<"$line" && [ "${standby_mode}" -ne 3 ]; then echo "${standby_bar}" && continue; fi
+        sed -u "$dict" <<<"${line}"
+    done < <(cava -p "$config_file")
+}
 
-# Read stdout from cava and perform substitution in a single sed command
-cava -p "$config_file" | sed -u "$dict"
+# Call the function
+listen_to_cava &
+disown # saves a tiny bit of memory


### PR DESCRIPTION
Customization capability for waybar cava

# Custom overrides: 

custom
![image](https://github.com/user-attachments/assets/d26e3de5-c1e7-49d1-b73c-9dce4e378fcc)

standbymode = 0 : clean (default) 
![image](https://github.com/user-attachments/assets/91f9cb80-5cd6-4aad-aec9-d4e7fcb06bb8)
standbymode = 1 : blank space
![image](https://github.com/user-attachments/assets/257df0fc-0b79-4d04-bd71-b191394fd08e)
standbymode = 2 : full bar preview
![image](https://github.com/user-attachments/assets/959b2886-dcec-4c64-9c1e-36d258d68fe9)
standbymode = 3 : low -est bar will be displayed
![image](https://github.com/user-attachments/assets/9ff1757c-e4cb-4abe-8761-c3f67a5556eb)


# CLI  

![image](https://github.com/user-attachments/assets/bd7d1d91-4c3a-40ce-8075-94adfa194db2)

when set 
width: 
![image](https://github.com/user-attachments/assets/c704ae5c-4384-4a61-97aa-ebe19b2e7325)
range (It isn't good to touch this though, It helps to fine-tune if user wants to add more bar chararacters  )
 ![image](https://github.com/user-attachments/assets/7783dfc7-5972-4d81-ab15-0967b1e2d1a3)


# Other changes

* Disowns the parent shell so that we can strip off some memory 
* --restart just kills the cava instance then the waybar revives it after 1 second. 
* Added sleep for Cava for better power saving mode when nothing is playing then sed do not write anything

2 monitors so 2 instance 
![image](https://github.com/user-attachments/assets/2c96f738-e9ce-450c-a92e-0436a63ebd74)
cava sleeping
![image](https://github.com/user-attachments/assets/c9c50648-fb01-45a1-95bf-7dec20f7a860)
I can't capture it but if Cava is in idle mode it fetches for input every second hence in average it uses 1.2% peak when reading at 100ms and 0.2% peak when reading at 1000ms 
per cava instance which is super low and is efficient
![image](https://github.com/user-attachments/assets/cefc04af-6a26-4332-bf4a-ca045b36eacd)


# Fixes 
* Waybar cava gets killed by another instance of the script, this fixes it. 

# TODO

* Try to use a single instance of cava and recycle the output. 
