### PR TITLE
Simplify Zsh config and remove bloat

### DIFF
--- a/Configs/.zshrc
+++ b/Configs/.zshrc
@@ -51,7 +51,7 @@ setopt hist_ignore_dups
 setopt hist_find_no_dups
 
 # Completion styling
-zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'
+zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
 zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
 zstyle ':completion:*' menu no
 

--- a/Configs/.zshrc
+++ b/Configs/.zshrc
@@ -1,12 +1,84 @@
-# Oh-my-zsh installation path
-ZSH=/usr/share/oh-my-zsh/
+# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
+# Initialization code that may require console input (password prompts, [y/n]
+# confirmations, etc.) must go above this block; everything else may go below.
+if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
+  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+fi
 
-# Powerlevel10k theme path
-source /usr/share/zsh-theme-powerlevel10k/powerlevel10k.zsh-theme
+# Set the directory we want to store zinit and plugins
+ZINIT_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}/zinit/zinit.git"
 
-# List of plugins used
-plugins=()
-source $ZSH/oh-my-zsh.sh
+# Download Zinit, if it's not there yet
+if [ ! -d "$ZINIT_HOME" ]; then
+   mkdir -p "$(dirname $ZINIT_HOME)"
+   git clone https://github.com/zdharma-continuum/zinit.git "$ZINIT_HOME"
+fi
+
+# Source/Load zinit
+source "${ZINIT_HOME}/zinit.zsh"
+
+# Add in Powerlevel10k
+zinit ice depth=1; zinit light romkatv/powerlevel10k
+
+# Add in zsh plugins
+zinit light chrissicool/zsh-256color 
+zinit light zsh-users/zsh-syntax-highlighting
+zinit light zsh-users/zsh-completions
+zinit light zsh-users/zsh-autosuggestions
+
+# Add in snippets
+zinit snippet OMZP::git
+zinit snippet OMZP::sudo
+
+# Load completions
+autoload -Uz compinit && compinit
+
+zinit cdreplay -q
+
+# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
+[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
+
+# History
+HISTSIZE=5000
+HISTFILE=~/.zsh_history
+SAVEHIST=$HISTSIZE
+setopt appendhistory
+setopt sharehistory
+setopt hist_ignore_space
+setopt hist_ignore_all_dups
+setopt hist_save_no_dups
+setopt hist_ignore_dups
+setopt hist_find_no_dups
+
+# Completion styling
+zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'
+zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
+zstyle ':completion:*' menu no
+
+# Aliases
+alias c='clear'  # clear terminal
+alias l='eza -lh --icons=auto'  # long list
+alias ls='eza -1 --icons=auto'  # short list
+alias ll='eza -lha --icons=auto --sort=name --group-directories-first'  # long list all
+alias ld='eza -lhD --icons=auto'  # long list dirs
+alias lt='eza --icons=auto --tree'  # list folder as tree
+alias un='$aurhelper -Rns'  # uninstall package
+alias up='$aurhelper -Syu'  # update system/package/aur
+alias pl='$aurhelper -Qs'  # list installed package
+alias pa='$aurhelper -Ss'  # list available package
+alias pc='$aurhelper -Sc'  # remove unused cache
+alias po='$aurhelper -Qtdq | $aurhelper -Rns -'  # remove unused packages
+alias vc='code'  # gui code editor
+
+# Directory navigation shortcuts
+alias ..='cd ..'
+alias ...='cd ../..'
+alias .3='cd ../../..'
+alias .4='cd ../../../..'
+alias .5='cd ../../../../..'
+
+# Always mkdir a path (this doesn't inhibit functionality to make a single dir)
+alias mkdir='mkdir -p'
 
 # In case a command is not found, try to find the package that has it
 function command_not_found_handler {
@@ -56,34 +128,6 @@ function in {
         ${aurhelper} -S "${aur[@]}"
     fi
 }
-
-# Helpful aliases
-alias c='clear' # clear terminal
-alias l='eza -lh --icons=auto' # long list
-alias ls='eza -1 --icons=auto' # short list
-alias ll='eza -lha --icons=auto --sort=name --group-directories-first' # long list all
-alias ld='eza -lhD --icons=auto' # long list dirs
-alias lt='eza --icons=auto --tree' # list folder as tree
-alias un='$aurhelper -Rns' # uninstall package
-alias up='$aurhelper -Syu' # update system/package/aur
-alias pl='$aurhelper -Qs' # list installed package
-alias pa='$aurhelper -Ss' # list available package
-alias pc='$aurhelper -Sc' # remove unused cache
-alias po='$aurhelper -Qtdq | $aurhelper -Rns -' # remove unused packages, also try > $aurhelper -Qqd | $aurhelper -Rsu --print -
-alias vc='code' # gui code editor
-
-# Directory navigation shortcuts
-alias ..='cd ..'
-alias ...='cd ../..'
-alias .3='cd ../../..'
-alias .4='cd ../../../..'
-alias .5='cd ../../../../..'
-
-# Always mkdir a path (this doesn't inhibit functionality to make a single dir)
-alias mkdir='mkdir -p'
-
-# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh
-[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
 # Display Pokemon
 pokemon-colorscripts --no-title -r 1,3,6

--- a/Scripts/custom_hypr.lst
+++ b/Scripts/custom_hypr.lst
@@ -68,8 +68,6 @@ code                                                   # ide text editor
 
 # --------------------------------------------------- // Shell
 eza|zsh                                                # file lister for zsh
-oh-my-zsh-git|zsh                                      # plugin manager for zsh
-zsh-theme-powerlevel10k-git|zsh oh-my-zsh-git          # theme for zsh
 eza|fish                                               # file lister for fish
 starship|fish                                          # customizable shell prompt
 fastfetch                                              # system information fetch tool

--- a/Scripts/restore_cfg.lst
+++ b/Scripts/restore_cfg.lst
@@ -1,4 +1,4 @@
-N|Y|${HOME}|.zshrc .p10k.zsh|zsh oh-my-zsh-git zsh-theme-powerlevel10k pokemon-colorscripts-git
+N|Y|${HOME}|.zshrc .p10k.zsh|zsh pokemon-colorscripts-git
 N|Y|${HOME}/.config/Code/User|settings.json|visual-studio-code-bin
 N|Y|${HOME}/.config/Code - OSS/User|settings.json|code
 N|Y|${HOME}/.config|code-flags.conf|visual-studio-code-bin

--- a/Scripts/restore_zsh.lst
+++ b/Scripts/restore_zsh.lst
@@ -1,8 +1,0 @@
-git                                                     # alias and functions for git commands
-sudo                                                    # press ESC key twice to execute command with sudo prefix 
-#python                                                 # alias for python
-#zsh-interactive-cd                                     # press tab to change dir with fzf
-https://github.com/chrissicool/zsh-256color             # enhance terminal environment with 256 colors
-#https://github.com/zsh-users/zsh-completions           # press tab to complete command
-https://github.com/zsh-users/zsh-autosuggestions        # suggests commands as you type based on history
-https://github.com/zsh-users/zsh-syntax-highlighting    # highlights commands as you type


### PR DESCRIPTION
# Pull Request

## Description

In my [feature request](https://github.com/prasanthrangan/hyprdots/issues/1880), I initially misstated that Powerlevel10k was unmaintained. However, recent activity shows it is still receiving updates.

- Revised Zsh Configuration: Improved clarity and ease of user configuration, maintaining the same functionality.
- Removed Dependencies: Eliminated the need for additional packages like Powerlevel10k and Oh My Zsh, simplifying the setup.
- Plugin Management: Utilised Zinit as the plugin manager and added three previously used plugins.
- Omitted Oh My Zsh: Chose not to include Oh My Zsh due to its bloat and noticeable impact on shell startup time.
- Implemented Zinit Snippets: Added plugins using Zinit’s snippet functionality for installation via URL.

Additional Notes:
- The maintainer of these dotfiles may need to review restore_shl.sh, as I’m uncertain about what to remove to prevent potential issues.

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [x] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.