### PR TITLE
perf: skips swwwallcache if exists & skips wallbash if disabled

### DIFF
--- a/Configs/.local/share/bin/swwwallpaper.sh
+++ b/Configs/.local/share/bin/swwwallpaper.sh
@@ -15,8 +15,14 @@ Wall_Cache()
 {
     ln -fs "${wallList[setIndex]}" "${wallSet}"
     ln -fs "${wallList[setIndex]}" "${wallCur}"
-    "${scrDir}/swwwallcache.sh" -w "${wallList[setIndex]}" &> /dev/null
-    "${scrDir}/swwwallbash.sh" "${wallList[setIndex]}" &
+    # cache should only run if the file does not exist (eg new wallpaper added, or cache cleared)
+     if [ ! -f "${thmbDir}/${wall_hash}.thmb" ] || [ "${wallList[setIndex]}" -nt "${thmbDir}/${wall_hash}.thmb" ]; then
+        "${scrDir}/swwwallcache.sh" -w "${wallList[setIndex]}" &> /dev/null
+    fi
+    # wallbash should not be run if the option is not enabled
+    if [ "${enableWallDcol}" -ne 0 ]; then
+        "${scrDir}/swwwallbash.sh" "${wallList[setIndex]}" &
+    fi
     ln -fs "${thmbDir}/${wallHash[setIndex]}.sqre" "${wallSqr}"
     ln -fs "${thmbDir}/${wallHash[setIndex]}.thmb" "${wallTmb}"
     ln -fs "${thmbDir}/${wallHash[setIndex]}.blur" "${wallBlr}"


### PR DESCRIPTION
# Pull Request

## Description

swww wall cache and wallbash are currently generated on every wallpaper change.

I've added a check for the existing files before running `swwallcache.sh`, this will still enable cache generation for new wallpapers added to the directory

Additionally, I've added a check if the users current theme is not wallbash. I'm not sure if its by design to have `swwwallbash.sh` run on wallpaper changes if the user has not selected wallbash for the theme.

considering cache is generated for the entire theme on install and patch

`install.sh : 174`
```bash
 echo -e "\n\033[0;32m[cache]\033[0m generating cache files..."
 "$HOME/.local/share/bin/swwwallcache.sh" -t ""
```
`themepatcher.sh : 174`
```bash
[ "${3}" == "--skipcaching" ] || "$HOME/.local/share/bin/swwwallcache.sh" -t "${Fav_Theme}"
```
and wallbash is enabled by default

`hyde.conf :47` 
```conf
enableWallDcol="2"
```
both cache and wallbash will generate by default anyway

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

