### PR TITLE
replace pokemon-colorscripts with pokeget

### DIFF
--- a/Configs/.zshrc
+++ b/Configs/.zshrc
@@ -86,4 +86,4 @@ alias mkdir='mkdir -p'
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
 # Display Pokemon
-pokemon-colorscripts --no-title -r 1,3,6
+pokeget random --hide-name

--- a/Scripts/custom_hypr.lst
+++ b/Scripts/custom_hypr.lst
@@ -73,7 +73,7 @@ zsh-theme-powerlevel10k-git|zsh oh-my-zsh-git          # theme for zsh
 eza|fish                                               # file lister for fish
 starship|fish                                          # customizable shell prompt
 fastfetch                                              # system information fetch tool
-pokemon-colorscripts-git|zsh                           # display pokemon sprites
+pokeget|zsh                           # display pokemon sprites
 
 # --------------------------------------------------- // HyDE
 hyde-cli-git                                           # cli tool to manage hyde


### PR DESCRIPTION
# Pull Request

## Description

- Replace pokemon-colorscripts-git with pokeget-rs because its rust, actively maintained, faster,etc.....
- https://github.com/talwat/pokeget-rs

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots
![240930_14h28m43s_screenshot](https://github.com/user-attachments/assets/78b97f65-9010-442f-ae40-19a85790eefb)

## Additional context

**pokeget vs other similar project**
![240930_14h21m23s_screenshot](https://github.com/user-attachments/assets/bd0739ea-e046-4bf2-8c4e-33815ffcd099)

**pokeget vs pokemon-colorscripts**
![240930_14h21m48s_screenshot](https://github.com/user-attachments/assets/5ab3dfb1-984b-45c2-ba3c-2519ec8945c5)
