### PR TITLE
[theme maintainers] option to strictly implement colors for themes

### DIFF
--- a/Configs/.local/share/bin/swwwallbash.sh
+++ b/Configs/.local/share/bin/swwwallbash.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env sh
 
-
 #// set variables
 
 export scrDir="$(dirname "$(realpath "$0")")"
@@ -23,6 +22,11 @@ fi
 
 set -a
 source "${wallbashOut}"
+if [ -f "${hydeThemeDir}/theme.dcol" ]; then
+    source "${hydeThemeDir}/theme.dcol"
+    echo "[theme] Overriding dominant colors from \"${hydeTheme}\""
+    echo "[note] Remove \"${hydeThemeDir}/theme.dcol\" to use wallpaper dominant colors"
+fi
 [ "${dcol_mode}" == "dark" ] && dcol_invt="light" || dcol_invt="dark"
 set +a
 
@@ -259,4 +263,3 @@ if [ "${enableWallDcol}" -eq 0 ]; then
 fi
 
 find "${wallbashDir}/Wall-Ways" -type f -name "*.dcol" | parallel fn_wallbash {}
-

--- a/Configs/.local/share/bin/swwwallbash.sh
+++ b/Configs/.local/share/bin/swwwallbash.sh
@@ -13,7 +13,6 @@ if [ -z "${wallbashImg}" ] || [ ! -f "${wallbashImg}" ] ; then
     echo "Error: Input wallpaper not found!"
     exit 1
 fi
-
 wallbashOut="${dcolDir}/$(set_hash "${wallbashImg}").dcol"
 
 if [ ! -f "${wallbashOut}" ] ; then
@@ -22,7 +21,7 @@ fi
 
 set -a
 source "${wallbashOut}"
-if [ -f "${hydeThemeDir}/theme.dcol" ]; then
+if [ -f "${hydeThemeDir}/theme.dcol" ] && [ "${enableWallDcol}" -eq 0 ]  ; then
     source "${hydeThemeDir}/theme.dcol"
     echo "[theme] Overriding dominant colors from \"${hydeTheme}\""
     echo "[note] Remove \"${hydeThemeDir}/theme.dcol\" to use wallpaper dominant colors"

--- a/Scripts/themepatcher.sh
+++ b/Scripts/themepatcher.sh
@@ -115,6 +115,10 @@ while IFS= read -r fchk; do
         print_prompt -y "[!!] " "${fchk} --> do not exist in ${Theme_Dir}/Configs/"
     fi
 done <<< "$config"
+if [ -f "${Fav_Theme_Dir}/theme.dcol" ];then
+print_prompt -n "[ok] "  "found theme.dcol to override wallpaper dominant colors"
+restore_list+="Y|Y|\${HOME}/.config/hyde/themes/${Fav_Theme}|theme.dcol|hyprland\n"
+fi
 readonly restore_list
 
 # Get Wallpapers


### PR DESCRIPTION
# Pull Request

## Description

Closes https://github.com/prasanthrangan/hyprdots/issues/1904
Prevents [confusion with theme mode and wallbash mode ](https://github.com/prasanthrangan/hyprdots/pull/1889) 

Reason: 
It's the feat req of Khing. 
This way theme maintainers can optionally ship the intended dominant color files.  

TODO: 

* themepatcher.sh should support if file exist
* Hyde theme import should also be updated 