### PR TITLE
[wallpapers] Exposes a copy of the wallpaper so sddm can use it 

### DIFF
--- a/Configs/.local/share/bin/swwwallpaper.sh
+++ b/Configs/.local/share/bin/swwwallpaper.sh
@@ -22,6 +22,8 @@ Wall_Cache()
     ln -fs "${thmbDir}/${wallHash[setIndex]}.blur" "${wallBlr}"
     ln -fs "${thmbDir}/${wallHash[setIndex]}.quad" "${wallQad}"
     ln -fs "${dcolDir}/${wallHash[setIndex]}.dcol" "${wallDcl}"
+    [ ! -d /var/tmp/hyde/ ]  && mkdir  /var/tmp/hyde/ 
+    [ -d /var/tmp/hyde/ ] && cp "${wallSet}" /var/tmp/hyde/ # Only link as this is public
 }
 
 Wall_Change()


### PR DESCRIPTION
# Pull Request

This is the easiest way to make the current wallpaper into a display-manager wallpaper.  Or any system to access a file. 

Make a copy of the file into ` /var/tmp/hyde/wall.set ` 

# Set current wallpaper as  Sddm display picture
change `Background=*` into 
`Background="/var/tmp/hyde/wall.set" `    This is the path of the copied wallpaper.
![image](https://github.com/user-attachments/assets/b5e67598-3bdb-41bd-8abc-b84948771eb2)


# Anyone can access this image so don't put anything confidential as the wallpaper. LOL