### PR TITLE
wlogout variable btn_col now follows theme.dcol and hypr.theme in theme mode

### DIFF
--- a/Configs/.local/share/bin/logoutlaunch.sh
+++ b/Configs/.local/share/bin/logoutlaunch.sh
@@ -55,6 +55,16 @@ export fntSize=$(( y_mon * 2 / 100 ))
 #// detect wallpaper brightness
 
 [ -f "${cacheDir}/wall.dcol" ] && source "${cacheDir}/wall.dcol"
+#  Theme mode: detects the color-scheme set in hypr.theme and falls back if nothing is parsed.
+if [ "${enableWallDcol}" -eq 0 ]; then
+    colorScheme="$({ grep -q "^[[:space:]]*\$COLOR[-_]SCHEME\s*=" "${hydeThemeDir}/hypr.theme" && grep "^[[:space:]]*\$COLOR[-_]SCHEME\s*=" "${hydeThemeDir}/hypr.theme" | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' ;} || 
+                        grep 'gsettings set org.gnome.desktop.interface color-scheme' "${hydeThemeDir}/hypr.theme" | awk -F "'" '{print $((NF - 1))}')"
+    colorScheme=${colorScheme:-$(gsettings get org.gnome.desktop.interface color-scheme)} 
+    # should be declared explicitly so we can easily debug
+    grep -q "dark" <<< "${colorScheme}" && dcol_mode="dark"
+    grep -q "light" <<< "${colorScheme}" && dcol_mode="light"
+[ -f "${hydeThemeDir}/theme.dcol" ] && source "${hydeThemeDir}/theme.dcol"
+fi
 [ "${dcol_mode}" == "dark" ] && export BtnCol="white" || export BtnCol="black"
 
 


### PR DESCRIPTION
# Pull Request

## Description
wlogout button color only followed the dcol_mode of the orignal cached wallpaper (wall.dcol) and not the color scheme set in hypr.theme or theme.dcol in theme mode 

this fixes the issues and makes it so that it follows hypr.theme or theme.dcol (if present) in theme mode and wall.dcol of the original cached wallpaper in wallbash auto/dark/light modes.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots
**before :**
![241001_21h46m37s_screenshot](https://github.com/user-attachments/assets/ecbb003e-1fb1-4bf9-9d28-9fd5d30c1ec1)

**after :**
![image](https://github.com/user-attachments/assets/aea53677-bbde-46f1-85e1-454af69afe29)
