### PR TITLE
Change opacity rule for new version of vscode

### DIFF
--- a/Configs/.config/hypr/windowrules.conf
+++ b/Configs/.config/hypr/windowrules.conf
@@ -7,7 +7,7 @@
 windowrulev2 = opacity 0.90 0.90,class:^(firefox)$
 windowrulev2 = opacity 0.90 0.90,class:^(Brave-browser)$
 windowrulev2 = opacity 0.80 0.80,class:^(code-oss)$
-windowrulev2 = opacity 0.80 0.80,class:^(Code)$
+windowrulev2 = opacity 0.80 0.80,class:^([Cc]ode)$
 windowrulev2 = opacity 0.80 0.80,class:^(code-url-handler)$
 windowrulev2 = opacity 0.80 0.80,class:^(code-insiders-url-handler)$
 windowrulev2 = opacity 0.80 0.80,class:^(kitty)$


### PR DESCRIPTION
# Pull Request

## Description

VSCode 1.95 have different class name with lowercase letters. I have changed opacity rule to be applied correctly

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Additional context

Output of `hyprctl clients`
```
Window 5d9524c7f420 -> Release Notes: 1.95.0 - Visual Studio Code:
	mapped: 1
	hidden: 0
	at: 1930,47
	size: 945,1023
	workspace: 8 (8)
	floating: 0
	pseudo: 0
	monitor: 1
	class: code
	title: Release Notes: 1.95.0 - Visual Studio Code
	initialClass: code
	initialTitle: Visual Studio Code
	pid: 256694
	xwayland: 0
	pinned: 0
	fullscreen: 0
	fullscreenClient: 0
	grouped: 0
	tags: 
	swallowing: 0
	focusHistoryID: 1
```
