### PR TITLE
Dunst: set per-app notification icons

### DIFF
--- a/Configs/.config/dunst/dunst.conf
+++ b/Configs/.config/dunst/dunst.conf
@@ -217,7 +217,7 @@
     # Scale small icons up to this size, set to 0 to disable. Helpful
     # for e.g. small files or high-dpi screens. In case of conflict,
     # max_icon_size takes precedence over this.
-    min_icon_size = 32
+    min_icon_size = 128
 
     # Scale larger icons down to this size, set to 0 to disable
     max_icon_size = 128

--- a/Configs/.config/dunst/dunst.conf
+++ b/Configs/.config/dunst/dunst.conf
@@ -19,6 +19,13 @@
     # will be ignored.
     follow = mouse
 
+    # When set to true (recommended), you can use POSIX regular expressions for filtering rules.
+    # It uses the POSIX Extended Regular Expression syntax: https://en.m.wikibooks.org/wiki/Regular_Expressions/POSIX-Extended_Regular_Expressions.
+    #
+    # If this is set to false (not recommended), dunst will us fnmatch(3) for matching strings.
+    # Dunst doesn't pass any flags to fnmatch, so you cannot make use of extended patterns.
+    enable_posix_regex = true
+
     ### Geometry ###
 
     # dynamic width from 0 to 300
@@ -201,9 +208,8 @@
     #enable_recursive_icon_lookup = true
 
     # Set icon theme (only used for recursive icon lookup)
-    #icon_theme = Adwaita
     # You can also set multiple icon themes, with the leftmost one being used first.
-    icon_theme = "Tela-circle-dracula"
+    #icon_theme = "Tela-circle-dracula"
 
     # Align icons left/right/top/off
     icon_position = left
@@ -215,9 +221,6 @@
 
     # Scale larger icons down to this size, set to 0 to disable
     max_icon_size = 128
-
-    # Paths to default icons (only necessary when not using recursive icon lookup)
-    icon_path = $HOME/.icons/Tela-circle-dracula/16/actions:$HOME/.icons/Tela-circle-dracula/16/apps:$HOME/.icons/Tela-circle-dracula/16/devices:$HOME/.icons/Tela-circle-dracula/16/mimetypes:$HOME/.icons/Tela-circle-dracula/16/panel:$HOME/.icons/Tela-circle-dracula/16/places:$HOME/.icons/Tela-circle-dracula/16/status
 
     ### History ###
 

--- a/Configs/.config/dunst/dunstrc
+++ b/Configs/.config/dunst/dunstrc
@@ -19,6 +19,13 @@
     # will be ignored.
     follow = mouse
 
+   # When set to true (recommended), you can use POSIX regular expressions for filtering rules.
+    # It uses the POSIX Extended Regular Expression syntax: https://en.m.wikibooks.org/wiki/Regular_Expressions/POSIX-Extended_Regular_Expressions.
+    #
+    # If this is set to false (not recommended), dunst will us fnmatch(3) for matching strings.
+    # Dunst doesn't pass any flags to fnmatch, so you cannot make use of extended patterns.
+    enable_posix_regex = true
+
     ### Geometry ###
 
     # dynamic width from 0 to 300
@@ -198,12 +205,12 @@
 
     # Recursive icon lookup. You can set a single theme, instead of having to
     # define all lookup paths.
-    enable_recursive_icon_lookup = true
+    #enable_recursive_icon_lookup = true
 
     # Set icon theme (only used for recursive icon lookup)
     #icon_theme = Adwaita
     # You can also set multiple icon themes, with the leftmost one being used first.
-    icon_theme = "Tela-circle-dracula"
+    #icon_theme = "Tela-circle-dracula"
 
     # Align icons left/right/top/off
     icon_position = left

--- a/Configs/.config/dunst/dunstrc
+++ b/Configs/.config/dunst/dunstrc
@@ -198,7 +198,7 @@
 
     # Recursive icon lookup. You can set a single theme, instead of having to
     # define all lookup paths.
-    #enable_recursive_icon_lookup = true
+    enable_recursive_icon_lookup = true
 
     # Set icon theme (only used for recursive icon lookup)
     #icon_theme = Adwaita
@@ -215,9 +215,6 @@
 
     # Scale larger icons down to this size, set to 0 to disable
     max_icon_size = 128
-
-    # Paths to default icons (only necessary when not using recursive icon lookup)
-    icon_path = $HOME/.icons/Tela-circle-dracula/16/actions:$HOME/.icons/Tela-circle-dracula/16/apps:$HOME/.icons/Tela-circle-dracula/16/devices:$HOME/.icons/Tela-circle-dracula/16/mimetypes:$HOME/.icons/Tela-circle-dracula/16/panel:$HOME/.icons/Tela-circle-dracula/16/places:$HOME/.icons/Tela-circle-dracula/16/status
 
     ### History ###
 

--- a/Configs/.config/hyde/wallbash/Wall-Ways/notification/dunst.dcol
+++ b/Configs/.config/hyde/wallbash/Wall-Ways/notification/dunst.dcol
@@ -13,3 +13,15 @@ $HOME/.config/dunst/wallbash.conf|${scrDir}/wallbashdunst.sh
     frame_color = "#<wallbash_2xa2>03"
     icon = "$HOME/.config/dunst/icons/hyprdots.svg"
     timeout = 5
+
+[slack]
+    desktop_entry="^Slack$"
+    new_icon="$HOME/.icons/$iconTheme/scalable/apps/slack.svg"
+
+[telegram]
+    desktop_entry="^Telegram Desktop$"
+    new_icon="$HOME/.icons/$iconTheme/scalable/apps/telegram-desktop.svg"
+
+[skype]
+    desktop_entry="^Skype$"
+    new_icon="$HOME/.icons/$iconTheme/scalable/apps/skype.svg"

--- a/Configs/.local/share/bin/wallbashdunst.sh
+++ b/Configs/.local/share/bin/wallbashdunst.sh
@@ -8,9 +8,11 @@ dstDir="${confDir}/dunst"
 
 # regen conf
 
+export iconTheme="$({ grep -q "^[[:space:]]*\$ICON[-_]THEME\s*=" "${hydeThemeDir}/hypr.theme" && grep "^[[:space:]]*\$ICON[-_]THEME\s*=" "${hydeThemeDir}/hypr.theme" | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' ;} || 
+              grep 'gsettings set org.gnome.desktop.interface icon-theme' "${hydeThemeDir}/hypr.theme" | awk -F "'" '{print $(NF - 1)}')"
+
 export hypr_border
 envsubst < "${dstDir}/dunst.conf" > "${dstDir}/dunstrc"
 envsubst < "${dstDir}/wallbash.conf" >> "${dstDir}/dunstrc"
 killall dunst
 dunst &
-


### PR DESCRIPTION
# Pull Request

## Description

This PR adds ability to set per-application icons for dunst notification messages to better distinct one from another.

Please not that I have increased `min_icon_size` to 128, because dafualt `hyprdots.svg` image have size 300x300 in svg code, but themed icons don't, and without this change amended notifications looks smaller.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/f669b940-fff1-4eb4-b9fd-1009338fc3c4)

### After
![image](https://github.com/user-attachments/assets/5ec26fda-d209-4a5f-98fe-dd861e44e76b)

