### PR TITLE
Fix: `xdg-desktop-portal-gtk` windowrule improve

### DIFF
--- a/Configs/.config/hypr/windowrules.conf
+++ b/Configs/.config/hypr/windowrules.conf
@@ -89,7 +89,7 @@ windowrule = float,title:^(Choose Files)$
 windowrule = float,title:^(Save As)$
 windowrule = float,title:^(Confirm to replace files)$
 windowrule = float,title:^(File Operation Progress)$
-windowrulev2 = float,class:^(xdg-desktop-portal-gtk)$
+windowrulev2 = float,class:^([Xx]dg-desktop-portal-gtk)$
 
 # █░░ ▄▀█ █▄█ █▀▀ █▀█   █▀█ █░█ █░░ █▀▀ █▀
 # █▄▄ █▀█ ░█░ ██▄ █▀▄   █▀▄ █▄█ █▄▄ ██▄ ▄█


### PR DESCRIPTION
# Pull Request

## Description

Some applications somehow spawn `xdg-desktop-portal-gtk` windows with first capital letter. This small PR consider this in windows rule.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

This windows was spawned by MeshLab
![image](https://github.com/user-attachments/assets/6ec5af9d-953b-41c8-afd6-99773e48e27d)
