### PR TITLE
fix: Dolphin/KDE fix for themes

### DIFF
--- a/Configs/.config/dolphinrc
+++ b/Configs/.config/dolphinrc
@@ -39,6 +39,3 @@ Plugins=appimagethumbnail,audiothumbnail,comicbookthumbnail,cursorthumbnail,djvu
 
 [Toolbar mainToolBar]
 ToolButtonStyle=IconOnly
-
-[UiSettings]
-ColorScheme=*

--- a/Configs/.config/kdeglobals
+++ b/Configs/.config/kdeglobals
@@ -3,3 +3,9 @@ TerminalApplication=kitty
 
 [Icons]
 Theme=Will be overwritten by themeswitch
+
+[Colors:View]
+BackgroundNormal=#00000000
+
+[UiSettings]
+ColorScheme=*


### PR DESCRIPTION
Made background transparent in kdeglobals so it does not interfere with theming.
Moved ColorScheme=* from DolpinRc to kdeglobals

Type of change
    [x ] Bug fix (non-breaking change which fixes an issue)

Checklist

[x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
[x] My code follows the code style of this project.
[x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
My change requires a change to the documentation.
I have updated the documentation accordingly.  
I have added a changelog entry.                                                                            ?
I have added necessary comments/documentation to my code.
I have added tests to cover my changes.
[x] I have tested my code locally and it works as expected.
All new and existing tests passed.                                                                         ?