### PR TITLE
Dunst: Patch config to display notifications correctly on >= 1.12

### DIFF
--- a/Configs/.config/dunst/dunst.conf
+++ b/Configs/.config/dunst/dunst.conf
@@ -27,7 +27,7 @@
     width = 300
 
     # The maximum height of a single notification, excluding the frame.
-    height = (140, 300)
+    height = (0, 300)
 
     # Position the notification in the top right corner
     origin = top-right

--- a/Configs/.config/dunst/dunst.conf
+++ b/Configs/.config/dunst/dunst.conf
@@ -27,13 +27,13 @@
     width = 300
 
     # The maximum height of a single notification, excluding the frame.
-    height = 300
+    height = (140, 300)
 
     # Position the notification in the top right corner
     origin = top-right
 
     # Offset from the origin
-    offset = 20x20
+    offset = (20, 20)
 
     # Scale factor. It is auto-detected if value is 0.
     scale = 0

--- a/Configs/.config/dunst/dunstrc
+++ b/Configs/.config/dunst/dunstrc
@@ -27,7 +27,7 @@
     width = 300
 
     # The maximum height of a single notification, excluding the frame.
-    height = (140, 300)
+    height = (0, 300)
 
     # Position the notification in the top right corner
     origin = top-right

--- a/Configs/.config/dunst/dunstrc
+++ b/Configs/.config/dunst/dunstrc
@@ -27,13 +27,13 @@
     width = 300
 
     # The maximum height of a single notification, excluding the frame.
-    height = 300
+    height = (140, 300)
 
     # Position the notification in the top right corner
     origin = top-right
 
     # Offset from the origin
-    offset = 20x20
+    offset = (20, 20)
 
     # Scale factor. It is auto-detected if value is 0.
     scale = 0


### PR DESCRIPTION
# Pull Request

## Description

Dunst 1.12 have chages in `height` implementation now only value is not implemented as "maximum height", but it is implemented as "fixed height", which leads to unnecesary space consumed by notification.

Quote from docs:

> Dunst v1.11 and older do not support a dynamic height and height accepts a single value whose behaviour is equivalent to (0, value).

I do not use `0,300` but use `140,300` instead to preserve some margin between icon and notification border

This small patch changes behavior like it was on older dunst versions.

Also changed `offset` value to new format, stated in [dunst docs](https://dunst-project.org/documentation/#Global-section)

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

