### PR TITLE
Add a keybind to toggle the blur of windows

### DIFF
--- a/Configs/.config/hypr/hyprland.conf
+++ b/Configs/.config/hypr/hyprland.conf
@@ -129,7 +129,8 @@ xwayland {
 
 source = ~/.config/hypr/animations.conf
 source = ~/.config/hypr/keybindings.conf
-source = ~/.config/hypr/windowrules.conf
+source = ~/.config/hypr/windowrules-blur.conf
+source = ~/.config/hypr/windowrules-float.conf
 source = ~/.config/hypr/themes/common.conf # shared theme settings
 # hyprlang noerror true
 source = ~/.config/hypr/themes/theme.conf # theme specific settings

--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -15,7 +15,7 @@ $file = dolphin
 $browser = firefox
 
 # Window/Session actions
-bindd = $mainMod+Shift, P,Color Picker , exec, hyprpicker -a # Pick color (Hex) >> clipboard# 
+bindd = $mainMod+Shift, P,Color Picker , exec, hyprpicker -a # Pick color (Hex) >> clipboard#
 bind = $mainMod, Q, exec, $scrPath/dontkillsteam.sh # close focused window
 bind = Alt, F4, exec, $scrPath/dontkillsteam.sh # close focused window
 bind = $mainMod, Delete, exit, # kill hyprland session
@@ -27,6 +27,7 @@ bind = $mainMod+Shift, F, exec, $scrPath/windowpin.sh # toggle pin on focused wi
 bind = $mainMod, Backspace, exec, $scrPath/logoutlaunch.sh # launch logout menu
 bind = Ctrl+Alt, W, exec, killall waybar || (env reload_flag=1 $scrPath/wbarconfgen.sh) # toggle waybar and reload config
 #bind = Ctrl+Alt, W, exec, killall waybar || waybar # toggle waybar without reloading, this is faster
+bind = $mainMod, B, exec, $scrPath/blurtoggle.sh # toggle blur of windows
 
 # Application shortcuts
 bind = $mainMod, T, exec, $term # launch terminal emulator
@@ -109,7 +110,7 @@ bind = $mainMod+Ctrl, Right, workspace, r+1
 bind = $mainMod+Ctrl, Left, workspace, r-1
 
 # Move to the first empty workspace
-bind = $mainMod+Ctrl, Down, workspace, empty 
+bind = $mainMod+Ctrl, Down, workspace, empty
 
 # Resize windows
 binde = $mainMod+Shift, Right, resizeactive, 30 0

--- a/Configs/.config/hypr/windowrules-blur.conf
+++ b/Configs/.config/hypr/windowrules-blur.conf
@@ -51,46 +51,6 @@ windowrulev2 = opacity 0.80 0.80,class:^(io.gitlab.adhami3310.Impression)$ # Imp
 windowrulev2 = opacity 0.80 0.80,class:^(io.missioncenter.MissionCenter)$ # MissionCenter-Gtk
 windowrulev2 = opacity 0.80 0.80,class:^(io.github.flattool.Warehouse)$ # Warehouse-Gtk
 
-windowrulev2 = float,class:^(org.kde.dolphin)$,title:^(Progress Dialog — Dolphin)$
-windowrulev2 = float,class:^(org.kde.dolphin)$,title:^(Copying — Dolphin)$
-windowrulev2 = float,title:^(About Mozilla Firefox)$
-windowrulev2 = float,class:^(firefox)$,title:^(Picture-in-Picture)$
-windowrulev2 = float,class:^(firefox)$,title:^(Library)$
-windowrulev2 = float,class:^(kitty)$,title:^(top)$
-windowrulev2 = float,class:^(kitty)$,title:^(btop)$
-windowrulev2 = float,class:^(kitty)$,title:^(htop)$
-windowrulev2 = float,class:^(vlc)$
-windowrulev2 = float,class:^(kvantummanager)$
-windowrulev2 = float,class:^(qt5ct)$
-windowrulev2 = float,class:^(qt6ct)$
-windowrulev2 = float,class:^(nwg-look)$
-windowrulev2 = float,class:^(org.kde.ark)$
-windowrulev2 = float,class:^(org.pulseaudio.pavucontrol)$
-windowrulev2 = float,class:^(blueman-manager)$
-windowrulev2 = float,class:^(nm-applet)$
-windowrulev2 = float,class:^(nm-connection-editor)$
-windowrulev2 = float,class:^(org.kde.polkit-kde-authentication-agent-1)$
-
-windowrulev2 = float,class:^(Signal)$ # Signal-Gtk
-windowrulev2 = float,class:^(com.github.rafostar.Clapper)$ # Clapper-Gtk
-windowrulev2 = float,class:^(app.drey.Warp)$ # Warp-Gtk
-windowrulev2 = float,class:^(net.davidotek.pupgui2)$ # ProtonUp-Qt
-windowrulev2 = float,class:^(yad)$ # Protontricks-Gtk
-windowrulev2 = float,class:^(eog)$ # Imageviewer-Gtk
-windowrulev2 = float,class:^(io.github.alainm23.planify)$ # planify-Gtk
-windowrulev2 = float,class:^(io.gitlab.theevilskeleton.Upscaler)$ # Upscaler-Gtk
-windowrulev2 = float,class:^(com.github.unrud.VideoDownloader)$ # VideoDownloader-Gkk
-windowrulev2 = float,class:^(io.gitlab.adhami3310.Impression)$ # Impression-Gtk
-windowrulev2 = float,class:^(io.missioncenter.MissionCenter)$ # MissionCenter-Gtk
-
-# common modals
-windowrule = float,title:^(Open)$
-windowrule = float,title:^(Choose Files)$
-windowrule = float,title:^(Save As)$
-windowrule = float,title:^(Confirm to replace files)$
-windowrule = float,title:^(File Operation Progress)$
-windowrulev2 = float,class:^(xdg-desktop-portal-gtk)$
-
 # █░░ ▄▀█ █▄█ █▀▀ █▀█   █▀█ █░█ █░░ █▀▀ █▀
 # █▄▄ █▀█ ░█░ ██▄ █▀▄   █▀▄ █▄█ █▄▄ ██▄ ▄█
 

--- a/Configs/.config/hypr/windowrules-float.conf
+++ b/Configs/.config/hypr/windowrules-float.conf
@@ -1,0 +1,46 @@
+
+# █░█░█ █ █▄░█ █▀▄ █▀█ █░█░█   █▀█ █░█ █░░ █▀▀ █▀
+# ▀▄▀▄▀ █ █░▀█ █▄▀ █▄█ ▀▄▀▄▀   █▀▄ █▄█ █▄▄ ██▄ ▄█
+
+# See https://wiki.hyprland.org/Configuring/Window-Rules/
+
+windowrulev2 = float,class:^(org.kde.dolphin)$,title:^(Progress Dialog — Dolphin)$
+windowrulev2 = float,class:^(org.kde.dolphin)$,title:^(Copying — Dolphin)$
+windowrulev2 = float,title:^(About Mozilla Firefox)$
+windowrulev2 = float,class:^(firefox)$,title:^(Picture-in-Picture)$
+windowrulev2 = float,class:^(firefox)$,title:^(Library)$
+windowrulev2 = float,class:^(kitty)$,title:^(top)$
+windowrulev2 = float,class:^(kitty)$,title:^(btop)$
+windowrulev2 = float,class:^(kitty)$,title:^(htop)$
+windowrulev2 = float,class:^(vlc)$
+windowrulev2 = float,class:^(kvantummanager)$
+windowrulev2 = float,class:^(qt5ct)$
+windowrulev2 = float,class:^(qt6ct)$
+windowrulev2 = float,class:^(nwg-look)$
+windowrulev2 = float,class:^(org.kde.ark)$
+windowrulev2 = float,class:^(org.pulseaudio.pavucontrol)$
+windowrulev2 = float,class:^(blueman-manager)$
+windowrulev2 = float,class:^(nm-applet)$
+windowrulev2 = float,class:^(nm-connection-editor)$
+windowrulev2 = float,class:^(org.kde.polkit-kde-authentication-agent-1)$
+
+windowrulev2 = float,class:^(Signal)$ # Signal-Gtk
+windowrulev2 = float,class:^(com.github.rafostar.Clapper)$ # Clapper-Gtk
+windowrulev2 = float,class:^(app.drey.Warp)$ # Warp-Gtk
+windowrulev2 = float,class:^(net.davidotek.pupgui2)$ # ProtonUp-Qt
+windowrulev2 = float,class:^(yad)$ # Protontricks-Gtk
+windowrulev2 = float,class:^(eog)$ # Imageviewer-Gtk
+windowrulev2 = float,class:^(io.github.alainm23.planify)$ # planify-Gtk
+windowrulev2 = float,class:^(io.gitlab.theevilskeleton.Upscaler)$ # Upscaler-Gtk
+windowrulev2 = float,class:^(com.github.unrud.VideoDownloader)$ # VideoDownloader-Gkk
+windowrulev2 = float,class:^(io.gitlab.adhami3310.Impression)$ # Impression-Gtk
+windowrulev2 = float,class:^(io.missioncenter.MissionCenter)$ # MissionCenter-Gtk
+
+# common modals
+windowrule = float,title:^(Open)$
+windowrule = float,title:^(Choose Files)$
+windowrule = float,title:^(Save As)$
+windowrule = float,title:^(Confirm to replace files)$
+windowrule = float,title:^(File Operation Progress)$
+windowrulev2 = float,class:^(xdg-desktop-portal-gtk)$
+

--- a/Configs/.local/share/bin/blurtoggle.sh
+++ b/Configs/.local/share/bin/blurtoggle.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Path to config
+file_path="${HOME}/.config/hypr/hyprland.conf"
+
+# Source/unsourced windowrules-blur.conf
+perl -i -pe 's|^(#\s*)?(source\s*=\s*~/.config/hypr/windowrules-blur\.conf)|$1 ? "$2" : "# $2"|e' "$file_path"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://github.com/prasanthrangan/hyprdots/assets/106020512/7f8fadc8-e293-4482-a
 
 <br><div align="center"><img width="12%" src="Source/assets/Arch.svg"/><br></div>
 
-<a id="installation"></a>  
+<a id="installation"></a>
 <img src="Source/assets/Installation.gif" width="200"/>
 ---
 
@@ -69,7 +69,7 @@ View installation instructions for HyDE in [Hyde-cli - Usage](https://github.com
 Please reboot after the install script completes and takes you to the SDDM login screen (or black screen) for the first time.
 For more details, please refer to the [installation wiki](https://github.com/prasanthrangan/hyprdots/wiki/Installation).
 
-<a id="updating"></a>  
+<a id="updating"></a>
 <img src="Source/assets/Updating.gif" width="200"/>
 ---
 
@@ -93,12 +93,12 @@ For more details, you can refer to [Hyde-cli - dots management wiki](https://git
   <a href="#-design-by-t2"><kbd> <br> 🡅 <br> </kbd></a>
 </div>
 
-<a id="themes"></a>  
+<a id="themes"></a>
 <img src="Source/assets/Themes.gif" width="200"/>
 ---
 
 All our official themes are stored in a separate repository, allowing users to install them using themepatcher.
-For more information, visit [HyDE-Project/hyde-themes](https://github.com/HyDE-Project/hyde-themes). 
+For more information, visit [HyDE-Project/hyde-themes](https://github.com/HyDE-Project/hyde-themes).
 
 <div align="center">
   <table><tr><td>
@@ -129,7 +129,7 @@ For more information, visit [HyDE-Project/hyde-themes](https://github.com/HyDE-P
   <a href="#-design-by-t2"><kbd> <br> 🡅 <br> </kbd></a>
 </div>
 
-<a id="styles"></a>  
+<a id="styles"></a>
 <img src="Source/assets/Styles.gif" width="200"/>
 ---
 
@@ -177,7 +177,7 @@ For more information, visit [HyDE-Project/hyde-themes](https://github.com/HyDE-P
   <a href="#-design-by-t2"><kbd> <br> 🡅 <br> </kbd></a>
 </div>
 
-<a id="keybindings"></a>  
+<a id="keybindings"></a>
 <img src="Source/assets/Keybindings.gif" width="200"/>
 ---
 
@@ -190,6 +190,7 @@ For more information, visit [HyDE-Project/hyde-themes](https://github.com/HyDE-P
 | <kbd>Super</kbd> + <kbd>Del</kbd> | Kill Hyprland session |
 | <kbd>Super</kbd> + <kbd>W</kbd> | Toggle the window between focus and float |
 | <kbd>Super</kbd> + <kbd>G</kbd> | Toggle the window between focus and group |
+| <kbd>Super</kbd> + <kbd>B</kbd> | Toggle the blur of windows |
 | <kbd>Super</kbd> + <kbd>slash</kbd> | Launch keybinds hint |
 | <kbd>Alt</kbd> + <kbd>Enter</kbd> | Toggle the window between focus and fullscreen |
 | <kbd>Super</kbd> + <kbd>L</kbd> | Launch lock screen |


### PR DESCRIPTION
# Pull Request

## Description
Introduces a convenient keybinding to toggle the blur effect of windows.
Provides a quick way to enable or disable the blur without needing to manually add windowrules for a specific program
I personally find this keybind very useful and I use it a lot.
## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.
