### PR TITLE
refactor(keybindings.conf): fix description of keybindings to move active window

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -136,10 +136,10 @@ bind = $mainMod+Ctrl+Alt, Left, movetoworkspace, r-1
 
 # Move active window around current workspace with mainMod + SHIFT + CTRL [←→↑↓]
 $moveactivewindow=grep -q "true" <<< $(hyprctl activewindow -j | jq -r .floating) && hyprctl dispatch moveactive
-binded = $mainMod SHIFT $CONTROL, left,Move activewindow to the right,exec, $moveactivewindow -30 0 || hyprctl dispatch movewindow l
-binded = $mainMod SHIFT $CONTROL, right,Move activewindow to the right,exec, $moveactivewindow 30 0 || hyprctl dispatch movewindow r
-binded = $mainMod SHIFT $CONTROL, up,Move activewindow to the right,exec, $moveactivewindow  0 -30 || hyprctl dispatch movewindow u
-binded = $mainMod SHIFT $CONTROL, down,Move activewindow to the right,exec, $moveactivewindow 0 30 || hyprctl dispatch movewindow d
+binded = $mainMod SHIFT $CONTROL, left, Move activewindow left, exec, $moveactivewindow -30 0 || hyprctl dispatch movewindow l
+binded = $mainMod SHIFT $CONTROL, right, Move activewindow right, exec, $moveactivewindow 30 0 || hyprctl dispatch movewindow r
+binded = $mainMod SHIFT $CONTROL, up, Move activewindow up, exec, $moveactivewindow  0 -30 || hyprctl dispatch movewindow u
+binded = $mainMod SHIFT $CONTROL, down, Move activewindow down, exec, $moveactivewindow 0 30 || hyprctl dispatch movewindow d
 
 # Scroll through existing workspaces
 bind = $mainMod, mouse_down, workspace, e+1


### PR DESCRIPTION
# Pull Request

## Description

This is a simple change that fixes the description shown to people using the keybinds hint for "Move Active Window Using Arrow Keys". It changes the description of all move active window keybindings from "move activewindow to the right" to "move activewindow <direction>"

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [X] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [X] I have tested my code locally and it works as expected.
- [X] All new and existing tests passed.
