### PR TITLE
Fixup `gpuinfo.sh` for amd gpu

### DIFF
--- a/Configs/.local/share/bin/gpuinfo.sh
+++ b/Configs/.local/share/bin/gpuinfo.sh
@@ -150,7 +150,6 @@ generate_json() {
   declare -A tooltip_parts
   if [[ -n "${utilization}" ]]; then tooltip_parts["\n$speedo Utilization: "]="${utilization}%" ; fi
   if [[ -n "${current_clock_speed}" ]] && [[ -n "${max_clock_speed}" ]]; then tooltip_parts["\n Clock Speed: "]="${current_clock_speed}/${max_clock_speed} MHz" ; fi
-  if [[ -n "${gpu_load}" ]]; then tooltip_parts["\n$speedo Utilization: "]="${gpu_load}%" ; fi
   if [[ -n "${core_clock}" ]]; then tooltip_parts["\n Clock Speed: "]="${core_clock} MHz" ;fi
   if [[ -n "${power_usage}" ]]; then if [[ -n "${power_limit}" ]]; then
                                     tooltip_parts["\n󱪉 Power Usage: "]="${power_usage}/${power_limit} W"
@@ -219,7 +218,7 @@ amd_GPU() { #? Function to query amd GPU
 if [[ ! ${amd_output} == *"No AMD GPUs detected."* ]] && [[ ! ${amd_output} == *"Unknown query failure"* ]]; then
   # Extract GPU Temperature, GPU Load, GPU Core Clock, and GPU Power Usage from amd_output
   temperature=$(echo "${amd_output}" | jq -r '.["GPU Temperature"]' | sed 's/°C//')
-  gpu_load=$(echo "${amd_output}" | jq -r '.["GPU Load"]' | sed 's/%//')
+  utilization=$(echo "${amd_output}" | jq -r '.["GPU Load"]' | sed 's/%//')
   core_clock=$(echo "${amd_output}" | jq -r '.["GPU Core Clock"]' | sed 's/ GHz//;s/ MHz//')
   power_usage=$(echo "${amd_output}" | jq -r '.["GPU Power Usage"]' | sed 's/ Watts//')
 


### PR DESCRIPTION
# Pull Request

## Description

On AMD GPUs `gpuinfo.sh` had one minor problem: `Utilization` always show "lowest" gauge icon not respecting the actual gpu load because of empty "utilization" variable on [row 154 ](https://github.com/prasanthrangan/hyprdots/blob/master/Configs/.local/share/bin/gpuinfo.sh#L154)

```json
{"text":" 38°C", "tooltip":"AMD Navi 14\n Temperature: 38°C ❄️\n󰾆 Utilization: 0.2%\n󱪉 Power Usage: 7 W\n Clock Speed: 492 MHz"}

{"text":" 86°C", "tooltip":"AMD Navi 14\n Temperature: 86°C 🌋\n󰾆 Utilization: 96.4%\n󱪉 Power Usage: 122 W\n Clock Speed: 850 MHz"}
```

This change rename `gpu_load -> utilization` in `amd_GPU()` function to match intel & nvidia functions.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.
